### PR TITLE
feat(startify): export mru() for more flexibility

### DIFF
--- a/lua/alpha/themes/startify.lua
+++ b/lua/alpha/themes/startify.lua
@@ -115,6 +115,7 @@ local opts = {
 
 return {
     button = button,
+    mru = mru,
     header = header,
     section = section,
     opts = opts,


### PR DESCRIPTION
Export startify theme `mru()` for more flexible customization.