### PR TITLE
refactor: replace `utils.from_nil` with `vim.F.if_nil`

### DIFF
--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -79,7 +79,7 @@ layout_element.text = function(el, opts, state)
         local end_ln = state.line + #el.val
         local val = el.val
         if opts.opts and opts.opts.margin and el.opts and (el.opts.position ~= "center") then
-            val = pad_margin(val, state, opts.opts.margin, utils.from_nil(el.opts.shrink_margin, true))
+            val = pad_margin(val, state, opts.opts.margin, vim.F.if_nil(el.opts.shrink_margin, true))
         end
         if el.opts then
             if el.opts.position == "center" then
@@ -105,7 +105,7 @@ layout_element.text = function(el, opts, state)
             table.insert(val, s)
         end
         if opts.opts and opts.opts.margin and el.opts and (el.opts.position ~= "center") then
-            val = pad_margin(val, state, opts.opts.margin, utils.from_nil(el.opts.shrink_margin, true))
+            val = pad_margin(val, state, opts.opts.margin, vim.F.if_nil(el.opts.shrink_margin, true))
         end
         if el.opts then
             if el.opts.position == "center" then
@@ -159,7 +159,7 @@ layout_element.button = function(el, opts, state)
 
     -- margin
     if opts.opts and opts.opts.margin and el.opts and (el.opts.position ~= "center") then
-        val = pad_margin(val, state, opts.opts.margin, utils.from_nil(el.opts.shrink_margin, true))
+        val = pad_margin(val, state, opts.opts.margin, vim.F.if_nil(el.opts.shrink_margin, true))
         if el.opts.align_shortcut == "right"
             then padding.center = padding.center + opts.opts.margin
             else padding.left = padding.left + opts.opts.margin

--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -1,6 +1,7 @@
 -- business logic
 
 local utils = require'alpha.utils'
+local if_nil = vim.F.if_nil
 
 local cursor_ix = 1
 local cursor_jumps = {}
@@ -79,7 +80,7 @@ layout_element.text = function(el, opts, state)
         local end_ln = state.line + #el.val
         local val = el.val
         if opts.opts and opts.opts.margin and el.opts and (el.opts.position ~= "center") then
-            val = pad_margin(val, state, opts.opts.margin, vim.F.if_nil(el.opts.shrink_margin, true))
+            val = pad_margin(val, state, opts.opts.margin, if_nil(el.opts.shrink_margin, true))
         end
         if el.opts then
             if el.opts.position == "center" then
@@ -105,7 +106,7 @@ layout_element.text = function(el, opts, state)
             table.insert(val, s)
         end
         if opts.opts and opts.opts.margin and el.opts and (el.opts.position ~= "center") then
-            val = pad_margin(val, state, opts.opts.margin, vim.F.if_nil(el.opts.shrink_margin, true))
+            val = pad_margin(val, state, opts.opts.margin, if_nil(el.opts.shrink_margin, true))
         end
         if el.opts then
             if el.opts.position == "center" then
@@ -159,7 +160,7 @@ layout_element.button = function(el, opts, state)
 
     -- margin
     if opts.opts and opts.opts.margin and el.opts and (el.opts.position ~= "center") then
-        val = pad_margin(val, state, opts.opts.margin, vim.F.if_nil(el.opts.shrink_margin, true))
+        val = pad_margin(val, state, opts.opts.margin, if_nil(el.opts.shrink_margin, true))
         if el.opts.align_shortcut == "right"
             then padding.center = padding.center + opts.opts.margin
             else padding.left = padding.left + opts.opts.margin

--- a/lua/alpha/utils.lua
+++ b/lua/alpha/utils.lua
@@ -17,13 +17,4 @@ function utils.memoize (f)
     end
 end
 
-function utils.from_nil(x, nil_case)
-    if x == nil
-        then return nil_case
-        else return x
-    end
-end
-
-
-
 return utils


### PR DESCRIPTION
There is an `if_nil` function built in to neovim already, so don't need to redefine one.
(Defined [here](https://github.com/neovim/neovim/blob/47f99d66440ae8be26b34531989ac61edc1ad9fe/runtime/lua/vim/F.lua#L7))