### PR TITLE
feat: "spacers"

### DIFF
--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -233,6 +233,7 @@ end
 
 local function layout_spacers(opts, state)
     local space = vim.api.nvim_win_get_height(state.window) - #vim.api.nvim_buf_get_lines(state.buffer, 0, -1, false)
+    space = math.max(space, 0)
     local space_lines = {}
     for _ = 1, space do
         table.insert(space_lines, "")


### PR DESCRIPTION
This PR adds a new type of `layout_element`, a "spacer", which (if there is additional space on screen once everything else is drawn) fills the remaining space.

Multiple spacers can be used at once to give a "vertically centered" layout (one spacer at the top, one at the bottom).
You can also put a spacer in the middle to have a top aligned block and a bottom aligned block.

The spacers are adjustable by changing their `val`, which changes the ratio of their size in relation to the other spacers.

---

I think I have managed to get it to work with everything else (e.g. `cursor_jumps`) properly but would be good to have other people testing.