### PR TITLE
fix: wrong activation condition for alpha-nvim

### DIFF
--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -375,6 +375,26 @@ local function enable_alpha(opts)
     end
 end
 
+local function should_skip_alpha()
+    if
+        vim.fn.argc() > 0 -- should probably figure out how to be smarter than this
+        or (
+            #vim.v.argv > 1
+            and not (
+              vim.tbl_contains(vim.v.argv, "-b")
+              or vim.tbl_contains(vim.v.argv, "-i")
+              or vim.tbl_contains(vim.v.argv, "-n")
+              or vim.tbl_contains(vim.v.argv, "--listen")
+              or vim.tbl_contains(vim.v.argv, "--startuptime")
+            )
+        )
+    then
+        return true
+    end
+
+    return false
+end
+
 local options
 
 local function start(on_vimenter, opts)
@@ -390,12 +410,9 @@ local function start(on_vimenter, opts)
     local buffer
     if on_vimenter
         then
-            if vim.o.insertmode -- Handle vim -y
-                or (not vim.o.modifiable) -- Handle vim -M
-                or vim.fn.argc() ~= 0 -- should probably figure out how to be smarter than this
-                or vim.tbl_contains(vim.v.argv, '-c')
-                -- or vim.fn.line2byte('$') ~= -1
-            then return end
+            if should_skip_alpha() then
+              return
+            end
             buffer = vim.api.nvim_get_current_buf()
         else
             if vim.bo.ft ~= 'alpha'


### PR DESCRIPTION
I have abstracted the loading condition for alpha-nvim into a separate function. There are basically two conditions:

1.  If the user have provided some file to nvim
2. The user does not provide a file, but uses some command line options.  In this case, for some of the command line options, it is still valid to show alpah-nvim startup sceen. For example, for option `-n` (no swap file), `-i` (use a certain shada file) etc.  Though the exact condition can be debated and I am open to suggestions and corrections.

I have also removed the `vim.o.modifiable` check since nvim does not support `-y` option and this is a nvim-only lua plugin, which does not support Vim.

On a side note, alpha-nvim used a non-conventional 4-space indentation, which makes it a little painful to work with since 2-space indentation seems that main stream 😿