### PR TITLE
Open all folds inside 'alpha' buffer.

### DIFF
--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -354,7 +354,7 @@ local function enable_alpha(opts)
     -- I don't have the patience to sort out a better way to do this
     -- or seperate out the buffer local options.
     vim.cmd [[
-        silent! setlocal bufhidden=wipe nobuflisted colorcolumn= foldcolumn=0 matchpairs= nocursorcolumn nocursorline nolist nonumber norelativenumber nospell noswapfile signcolumn=no synmaxcol& buftype=nofile filetype=alpha nowrap
+        silent! setlocal bufhidden=wipe nobuflisted colorcolumn= foldlevel=999 foldcolumn=0 matchpairs= nocursorcolumn nocursorline nolist nonumber norelativenumber nospell noswapfile signcolumn=no synmaxcol& buftype=nofile filetype=alpha nowrap
 
         augroup alpha_temp
         au!


### PR DESCRIPTION
This matters if `foldmethod=indent`. Without this change all indented 'alpha' text is shown in fold.