### PR TITLE
fix: do not start alpha-nvim when opening session

### DIFF
--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -419,15 +419,16 @@ local function should_skip_alpha()
     for _, arg in ipairs(vim.v.argv) do
         -- whitelisted arguments
         -- always open
-        if arg == "--startuptime"
+        if  arg == "--startuptime"
             then return false
         end
 
         -- blacklisted arguments
         -- always skip
-        if arg == "-b"
+        if  arg == "-b"
             -- commands, typically used for scripting
             or arg == "-c" or vim.startswith(arg, "+")
+            or arg == "-S"
             then return true
         end
     end

--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -426,7 +426,7 @@ local function should_skip_alpha()
                 return vim.startswith(s, "+")
             end, vim.v.argv) > 0
         )
-		or vim.tbl_contains(vim.v.argv, "-S")
+        or vim.tbl_contains(vim.v.argv, "-S")
     ) then return true end
 end
 

--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -426,6 +426,7 @@ local function should_skip_alpha()
                 return vim.startswith(s, "+")
             end, vim.v.argv) > 0
         )
+		or vim.tbl_contains(vim.v.argv, "-S")
     ) then return true end
 end
 


### PR DESCRIPTION
Ignore vim `-S` option that open session file.

I think it's better not start alpha-nvim when opening session with `nvim -S [session]`.