### PR TITLE
refactor: avoid using unnecessary globals

### DIFF
--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -15,10 +15,10 @@ local cursor_jumps_press = {}
 
 local function noop() end
 
-M.alpha_redraw = noop
-M.alpha_close = noop
+M.redraw = noop
+M.close = noop
 
-function M.alpha_press()
+function M.press()
     cursor_jumps_press[cursor_ix]()
 end
 
@@ -391,16 +391,16 @@ local function enable_alpha(opts)
 
         augroup alpha_temp
         au!
-        autocmd BufUnload <buffer> lua require('alpha').alpha_close()
-        autocmd CursorMoved <buffer> lua require('alpha').alpha_set_cursor()
+        autocmd BufUnload <buffer> lua require('alpha').close()
+        autocmd CursorMoved <buffer> lua require('alpha').set_cursor()
         augroup END
     ]])
 
     if opts.opts then
         if if_nil(opts.opts.redraw_on_resize, true) then
             vim.cmd([[
-                autocmd alpha_temp VimResized * lua require('alpha').alpha_redraw()
-                autocmd alpha_temp BufLeave,WinEnter,WinNew,WinClosed * lua require('alpha').alpha_redraw()
+                autocmd alpha_temp VimResized * lua require('alpha').redraw()
+                autocmd alpha_temp BufLeave,WinEnter,WinNew,WinClosed * lua require('alpha').redraw()
             ]])
         end
 
@@ -445,7 +445,7 @@ local options
 local function start(on_vimenter, opts)
     local window = vim.api.nvim_get_current_win()
 
-    M.alpha_set_cursor = function()
+    M.set_cursor = function()
         local cursor = vim.api.nvim_win_get_cursor(window)
         local closest_ix, closest_pt = closest_cursor_jump(cursor, cursor_jumps, cursor_jumps[cursor_ix])
         cursor_ix = closest_ix
@@ -505,17 +505,17 @@ local function start(on_vimenter, opts)
             state.buffer,
             "n",
             "<CR>",
-            "<cmd>lua require('alpha').alpha_press()<CR>",
+            "<cmd>lua require('alpha').press()<CR>",
             { noremap = false, silent = true }
         )
         vim.api.nvim_win_set_cursor(state.window, cursor_jumps[ix])
     end
-    M.alpha_redraw = draw
-    M.alpha_close = function()
+    M.redraw = draw
+    M.close = function()
         cursor_ix = 1
         cursor_jumps = {}
         cursor_jumps_press = {}
-        M.alpha_redraw = noop
+        M.redraw = noop
         vim.cmd([[au! alpha_temp]])
     end
     draw()
@@ -525,7 +525,7 @@ end
 local function setup(opts)
     vim.cmd([[
         command! Alpha lua require'alpha'.start(false)
-        command! AlphaRedraw lua require('alpha').alpha_redraw()
+        command! AlphaRedraw lua require('alpha').redraw()
         augroup alpha_start
         au!
         autocmd VimEnter * nested lua require'alpha'.start(true)

--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -1,4 +1,4 @@
-local M = {}
+local alpha = {}
 
 -- business logic
 local abs = math.abs
@@ -15,10 +15,10 @@ local cursor_jumps_press = {}
 
 local function noop() end
 
-M.redraw = noop
-M.close = noop
+alpha.redraw = noop
+alpha.close = noop
 
-function M.press()
+function alpha.press()
     cursor_jumps_press[cursor_ix]()
 end
 
@@ -37,7 +37,7 @@ local function spaces(n)
     return str_rep(" ", n)
 end
 
-local function align_center(tbl, state)
+function alpha.align_center(tbl, state)
     -- longest line used to calculate the center.
     -- which doesn't quite give a 'justfieid' look, but w.e
     local longest = longest_line(tbl)
@@ -51,7 +51,7 @@ local function align_center(tbl, state)
     return centered, left
 end
 
-local function pad_margin(tbl, state, margin, shrink)
+function alpha.pad_margin(tbl, state, margin, shrink)
     local longest = longest_line(tbl)
     local left
     if shrink then
@@ -81,7 +81,7 @@ end
 --     return trimmed
 -- end
 
-local function highlight(state, end_ln, hl, left)
+function alpha.highlight(state, end_ln, hl, left)
     local hl_type = type(hl)
     local hl_tbl = {}
     if hl_type == "string" then
@@ -107,7 +107,7 @@ end
 
 local layout_element = {}
 
-local function resolve(to, el, opts, state)
+function alpha.resolve(to, el, opts, state)
     local new_el = deepcopy(el)
     new_el.val = el.val()
     return to(new_el, opts, state)
@@ -121,19 +121,19 @@ function layout_element.text(el, opts, state)
         local padding = { left = 0 }
         if opts.opts and opts.opts.margin and el.opts and (el.opts.position ~= "center") then
             local left
-            val, left = pad_margin(val, state, opts.opts.margin, if_nil(el.opts.shrink_margin, true))
+            val, left = alpha.pad_margin(val, state, opts.opts.margin, if_nil(el.opts.shrink_margin, true))
             padding.left = padding.left + left
         end
         if el.opts then
             if el.opts.position == "center" then
-                val, _ = align_center(val, state)
+                val, _ = alpha.align_center(val, state)
             end
             -- if el.opts.wrap == "overflow" then
             --     val = trim(val, state)
             -- end
         end
         if el.opts and el.opts.hl then
-            hl = highlight(state, end_ln, el.opts.hl, padding.left)
+            hl = alpha.highlight(state, end_ln, el.opts.hl, padding.left)
         end
         state.line = end_ln
         return val, hl
@@ -148,24 +148,24 @@ function layout_element.text(el, opts, state)
         local padding = { left = 0 }
         if opts.opts and opts.opts.margin and el.opts and (el.opts.position ~= "center") then
             local left
-            val, left = pad_margin(val, state, opts.opts.margin, if_nil(el.opts.shrink_margin, true))
+            val, left = alpha.pad_margin(val, state, opts.opts.margin, if_nil(el.opts.shrink_margin, true))
             padding.left = padding.left + left
         end
         if el.opts then
             if el.opts.position == "center" then
-                val, _ = align_center(val, state)
+                val, _ = alpha.align_center(val, state)
             end
         end
         local end_ln = state.line + 1
         if el.opts and el.opts.hl then
-            hl = highlight(state, end_ln, el.opts.hl, padding.left)
+            hl = alpha.highlight(state, end_ln, el.opts.hl, padding.left)
         end
         state.line = end_ln
         return val, hl
     end
 
     if type(el.val) == "function" then
-        return resolve(layout_element.text, el, opts, state)
+        return alpha.resolve(layout_element.text, el, opts, state)
     end
 end
 
@@ -216,7 +216,7 @@ function layout_element.button(el, opts, state)
     -- margin
     if opts.opts and opts.opts.margin and el.opts and (el.opts.position ~= "center") then
         local left
-        val, left = pad_margin(val, state, opts.opts.margin, if_nil(el.opts.shrink_margin, true))
+        val, left = alpha.pad_margin(val, state, opts.opts.margin, if_nil(el.opts.shrink_margin, true))
         if el.opts.align_shortcut == "right" then
             padding.center = padding.center + left
         else
@@ -228,7 +228,7 @@ function layout_element.button(el, opts, state)
     if el.opts then
         if el.opts.position == "center" then
             local left
-            val, left = align_center(val, state)
+            val, left = alpha.align_center(val, state)
             if el.opts.align_shortcut == "right" then
                 padding.center = padding.center + left
             end
@@ -248,9 +248,9 @@ function layout_element.button(el, opts, state)
             hl = el.opts.hl_shortcut
         end
         if el.opts.align_shortcut == "right" then
-            hl = highlight(state, state.line, hl, #el.val + padding.center)
+            hl = alpha.highlight(state, state.line, hl, #el.val + padding.center)
         else
-            hl = highlight(state, state.line, hl, padding.left)
+            hl = alpha.highlight(state, state.line, hl, padding.left)
         end
     end
 
@@ -259,7 +259,7 @@ function layout_element.button(el, opts, state)
         if el.opts.align_shortcut == "left" then
             left = left + strdisplaywidth(el.opts.shortcut) + 2
         end
-        list_extend(hl, highlight(state, state.line, el.opts.hl, left))
+        list_extend(hl, alpha.highlight(state, state.line, el.opts.hl, left))
     end
     state.line = state.line + 1
     return val, hl
@@ -267,7 +267,7 @@ end
 
 function layout_element.group(el, opts, state)
     if type(el.val) == "function" then
-        return resolve(layout_element.group, el, opts, state)
+        return alpha.resolve(layout_element.group, el, opts, state)
     end
 
     if type(el.val) == "table" then
@@ -322,7 +322,7 @@ end
 
 function keymaps_element.group(el, opts, state)
     if type(el.val) == "function" then
-        resolve(keymaps_element.group, el, opts, state)
+        alpha.resolve(keymaps_element.group, el, opts, state)
     end
 
     if type(el.val) == "table" then
@@ -442,10 +442,10 @@ end
 
 local options
 
-local function start(on_vimenter, opts)
+function alpha.start(on_vimenter, opts)
     local window = vim.api.nvim_get_current_win()
 
-    M.move_cursor = function()
+    alpha.move_cursor = function()
         local cursor = vim.api.nvim_win_get_cursor(window)
         local closest_ix, closest_pt = closest_cursor_jump(cursor, cursor_jumps, cursor_jumps[cursor_ix])
         cursor_ix = closest_ix
@@ -510,19 +510,19 @@ local function start(on_vimenter, opts)
         )
         vim.api.nvim_win_set_cursor(state.window, cursor_jumps[ix])
     end
-    M.redraw = draw
-    M.close = function()
+    alpha.redraw = draw
+    alpha.close = function()
         cursor_ix = 1
         cursor_jumps = {}
         cursor_jumps_press = {}
-        M.redraw = noop
+        alpha.redraw = noop
         vim.cmd([[au! alpha_temp]])
     end
     draw()
     keymaps(opts, state)
 end
 
-local function setup(opts)
+function alpha.setup(opts)
     vim.cmd([[
         command! Alpha lua require'alpha'.start(false)
         command! AlphaRedraw lua require('alpha').redraw()
@@ -536,14 +536,7 @@ local function setup(opts)
     end
 end
 
-M.setup = setup
-M.start = start
-M.layout_element = layout_element
-M.keymaps_element = keymaps_element
-M.center = align_center
-M.resolve = resolve
-M.pad_margin = pad_margin
-M.highlight = highlight
-M.noop = noop
+alpha.layout_element = layout_element
+alpha.keymaps_element = keymaps_element
 
-return M
+return alpha

--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -1,3 +1,5 @@
+local M = {}
+
 -- business logic
 local abs = math.abs
 local concat = table.concat
@@ -13,10 +15,10 @@ local cursor_jumps_press = {}
 
 local function noop() end
 
-_G.alpha_redraw = noop
-_G.alpha_close = noop
+M.alpha_redraw = noop
+M.alpha_close = noop
 
-function _G.alpha_press()
+function M.alpha_press()
     cursor_jumps_press[cursor_ix]()
 end
 
@@ -389,16 +391,16 @@ local function enable_alpha(opts)
 
         augroup alpha_temp
         au!
-        autocmd BufUnload <buffer> call v:lua.alpha_close()
-        autocmd CursorMoved <buffer> call v:lua.alpha_set_cursor()
+        autocmd BufUnload <buffer> lua require('alpha').alpha_close()
+        autocmd CursorMoved <buffer> lua require('alpha').alpha_set_cursor()
         augroup END
     ]])
 
     if opts.opts then
         if if_nil(opts.opts.redraw_on_resize, true) then
             vim.cmd([[
-                autocmd alpha_temp VimResized * call v:lua.alpha_redraw()
-                autocmd alpha_temp BufLeave,WinEnter,WinNew,WinClosed * call v:lua.alpha_redraw()
+                autocmd alpha_temp VimResized * lua require('alpha').alpha_redraw()
+                autocmd alpha_temp BufLeave,WinEnter,WinNew,WinClosed * lua require('alpha').alpha_redraw()
             ]])
         end
 
@@ -443,7 +445,7 @@ local options
 local function start(on_vimenter, opts)
     local window = vim.api.nvim_get_current_win()
 
-    _G.alpha_set_cursor = function()
+    M.alpha_set_cursor = function()
         local cursor = vim.api.nvim_win_get_cursor(window)
         local closest_ix, closest_pt = closest_cursor_jump(cursor, cursor_jumps, cursor_jumps[cursor_ix])
         cursor_ix = closest_ix
@@ -503,17 +505,17 @@ local function start(on_vimenter, opts)
             state.buffer,
             "n",
             "<CR>",
-            "<cmd>call v:lua.alpha_press()<CR>",
+            "<cmd>lua require('alpha').alpha_press()<CR>",
             { noremap = false, silent = true }
         )
         vim.api.nvim_win_set_cursor(state.window, cursor_jumps[ix])
     end
-    _G.alpha_redraw = draw
-    _G.alpha_close = function()
+    M.alpha_redraw = draw
+    M.alpha_close = function()
         cursor_ix = 1
         cursor_jumps = {}
         cursor_jumps_press = {}
-        _G.alpha_redraw = noop
+        M.alpha_redraw = noop
         vim.cmd([[au! alpha_temp]])
     end
     draw()
@@ -523,7 +525,7 @@ end
 local function setup(opts)
     vim.cmd([[
         command! Alpha lua require'alpha'.start(false)
-        command! AlphaRedraw call v:lua.alpha_redraw()
+        command! AlphaRedraw lua require('alpha').alpha_redraw()
         augroup alpha_start
         au!
         autocmd VimEnter * nested lua require'alpha'.start(true)
@@ -534,14 +536,14 @@ local function setup(opts)
     end
 end
 
-return {
-    setup = setup,
-    start = start,
-    layout_element = layout_element,
-    keymaps_element = keymaps_element,
-    center = center,
-    resolve = resolve,
-    pad_margin = pad_margin,
-    highlight = highlight,
-    noop = noop,
-}
+M.setup = setup
+M.start = start
+M.layout_element = layout_element
+M.keymaps_element = keymaps_element
+M.center = center
+M.resolve = resolve
+M.pad_margin = pad_margin
+M.highlight = highlight
+M.noop = noop
+
+return M

--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -37,7 +37,7 @@ local function spaces(n)
     return str_rep(" ", n)
 end
 
-local function center(tbl, state)
+local function align_center(tbl, state)
     -- longest line used to calculate the center.
     -- which doesn't quite give a 'justfieid' look, but w.e
     local longest = longest_line(tbl)
@@ -126,7 +126,7 @@ function layout_element.text(el, opts, state)
         end
         if el.opts then
             if el.opts.position == "center" then
-                val, _ = center(val, state)
+                val, _ = align_center(val, state)
             end
             -- if el.opts.wrap == "overflow" then
             --     val = trim(val, state)
@@ -153,7 +153,7 @@ function layout_element.text(el, opts, state)
         end
         if el.opts then
             if el.opts.position == "center" then
-                val, _ = center(val, state)
+                val, _ = align_center(val, state)
             end
         end
         local end_ln = state.line + 1
@@ -228,7 +228,7 @@ function layout_element.button(el, opts, state)
     if el.opts then
         if el.opts.position == "center" then
             local left
-            val, left = center(val, state)
+            val, left = align_center(val, state)
             if el.opts.align_shortcut == "right" then
                 padding.center = padding.center + left
             end
@@ -540,7 +540,7 @@ M.setup = setup
 M.start = start
 M.layout_element = layout_element
 M.keymaps_element = keymaps_element
-M.center = center
+M.center = align_center
 M.resolve = resolve
 M.pad_margin = pad_margin
 M.highlight = highlight

--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -392,7 +392,7 @@ local function enable_alpha(opts)
         augroup alpha_temp
         au!
         autocmd BufUnload <buffer> lua require('alpha').close()
-        autocmd CursorMoved <buffer> lua require('alpha').set_cursor()
+        autocmd CursorMoved <buffer> lua require('alpha').move_cursor()
         augroup END
     ]])
 
@@ -445,7 +445,7 @@ local options
 local function start(on_vimenter, opts)
     local window = vim.api.nvim_get_current_win()
 
-    M.set_cursor = function()
+    M.move_cursor = function()
         local cursor = vim.api.nvim_win_get_cursor(window)
         local closest_ix, closest_pt = closest_cursor_jump(cursor, cursor_jumps, cursor_jumps[cursor_ix])
         cursor_ix = closest_ix

--- a/lua/alpha/themes/startify.lua
+++ b/lua/alpha/themes/startify.lua
@@ -227,7 +227,7 @@ local opts = {
         redraw_on_resize = false,
         setup = function()
             vim.cmd([[
-            autocmd alpha_temp DirChanged * call v:lua.alpha_redraw()
+            autocmd alpha_temp DirChanged * lua require('alpha').redraw()
             ]])
         end,
     },


### PR DESCRIPTION
Convert globals to native lua modules which are both more performant and generally encouraged.
