### PR TITLE
Skip input from stdin

### DIFF
--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -413,6 +413,9 @@ local function should_skip_alpha()
     -- don't start when opening a file
     if vim.fn.argc() > 0 then return true end
 
+    -- skip stdin
+    if vim.fn.line2byte("$") ~= -1 then return true end
+
     -- Handle nvim -M
     if not vim.o.modifiable then return true end
 


### PR DESCRIPTION
I don't want to start alpha-nvim with input from stdin.
`echo "aaaaa"	| nvim`

So, I'm porting this patch
https://github.com/glepnir/dashboard-nvim/blob/master/autoload/dashboard.vim#L36-L38