### PR TITLE
Fixes alpha-configuration tags in the helpdoc

### DIFF
--- a/doc/alpha.txt
+++ b/doc/alpha.txt
@@ -5,7 +5,7 @@ CONTENTS                                                        *alpha-contents*
 
     INTRO .......................................... |alpha-intro|
     COMMANDS ....................................... |alpha-commands|
-    OPTIONS ........................................ |alpha-options|
+    CONFIGURATION .................................. |alpha-configuration|
     AUTOCMD ........................................ |alpha-autocmd|
     COLORS ......................................... |alpha-colors|
     EXAMPLE ........................................ |alpha-example|
@@ -159,7 +159,7 @@ alpha supports the following autocmds
 - `autocmd User AlphaReady`
 
 there is an option to use *:noautocmd* when setting alpha's buffer local options
-see *alpha-configuration*
+see |alpha-configuration|
 
 ==============================================================================
 EXAMPLE                                                          *alpha-example*


### PR DESCRIPTION
I noticed an error when I ran `helptags ALL` related to a duplicate tag. While investigating, I noticed that one of the links to the `alpha-configuration` section was using the wrong syntax. I fixed that link and then began checking other links while I was there. I found that the `alpha-options` section in the table of contents, no longer existed. It appears that it was renamed to the previously mentioned `alpha-configuration` section. I updated the table of contents to reflect this change.