### PR TITLE
Support Windows path for file button

### DIFF
--- a/lua/alpha/themes/startify.lua
+++ b/lua/alpha/themes/startify.lua
@@ -96,7 +96,7 @@ local function file_button(fn, sc, short_fn)
         ico_txt = ""
     end
     local file_button_el = button(sc, ico_txt .. short_fn, "<cmd>e " .. fn .. " <CR>")
-    local fn_start = short_fn:match(".*/")
+    local fn_start = short_fn:match(".*[/\\]")
     if fn_start ~= nil then
         table.insert(fb_hl, { "Comment", #ico_txt - 2, #fn_start + #ico_txt - 2 })
     end

--- a/lua/alpha/themes/theta.lua
+++ b/lua/alpha/themes/theta.lua
@@ -50,7 +50,7 @@ local function file_button(fn, sc, short_fn)
         ico_txt = ""
     end
     local file_button_el = dashboard.button(sc, ico_txt .. short_fn, "<cmd>e " .. fn .. " <CR>")
-    local fn_start = short_fn:match(".*/")
+    local fn_start = short_fn:match(".*[/\\]")
     if fn_start ~= nil then
         table.insert(fb_hl, { "Comment", #ico_txt - 2, #fn_start + #ico_txt })
     end


### PR DESCRIPTION
On Windows, without this PR, path will be display as one for the whole path. Oppose to displaying a path and its file name separately on Unix-based systems.