### PR TITLE
feat: send User AlphaClosed autocommand on close

### DIFF
--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -562,6 +562,7 @@ function alpha.start(on_vimenter, conf)
         cursor_jumps_press = {}
         alpha.redraw = noop
         vim.cmd([[au! alpha_temp]])
+        vim.cmd([[doautocmd User AlphaClosed]])
     end
     draw()
     vim.cmd([[doautocmd User AlphaReady]])


### PR DESCRIPTION
When Alpha starts it sends the User AlphaReady autocommand. As a mirror
to that this patch adds a User AlphaClosed which runs when closing Alpha
to give users a chance to do whatever custom cleanup they need.