### PR TITLE
Fix text highlighting spilling over to next line

### DIFF
--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -185,11 +185,10 @@ function layout_element.text(el, conf, state)
                 padding.left = padding.left + left
             end
         end
-        local end_ln = state.line + 1
         if el.opts and el.opts.hl then
-            hl = alpha.highlight(state, end_ln, el.opts.hl, padding.left)
+            hl = alpha.highlight(state, state.line, el.opts.hl, padding.left)
         end
-        state.line = end_ln
+        state.line = state.line + 1
         return val, hl
     end
 

--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -173,9 +173,9 @@ function layout_element.text(el, conf, state)
             val[#val + 1] = s
         end
         local padding = { left = 0 }
-        if conf.opts and conf.opts.margin and el.opts and (el.opts.position ~= "center") then
+        if conf.opts and conf.opts.margin and (not el.opts or el.opts.position ~= "center") then
             local left
-            val, left = alpha.pad_margin(val, state, conf.opts.margin, if_nil(el.opts.shrink_margin, true))
+            val, left = alpha.pad_margin(val, state, conf.opts.margin, if_nil(el.opts and el.opts.shrink_margin, true))
             padding.left = padding.left + left
         end
         if el.opts then


### PR DESCRIPTION
Two small fixes

* The way `end_ln` was incremented before `alpha.highlight` meant that two calls to `vim.api.nvim_buf_add_highlight` were made for each text line (i.e. two highlight groups for each line rather than one), causing highlighting to affect the subsequent line.
* empty `opts` field in an element was preventing padding of line altogether

Before and after screenshots below w/ plain `startify` theme

<details>
  <summary>Diff of modifications to `startify.lua`</summary>

```diff
diff --git a/lua/alpha/themes/startify.lua b/lua/alpha/themes/startify.lua
index c38982e..8a6be2d 100644
--- a/lua/alpha/themes/startify.lua
+++ b/lua/alpha/themes/startify.lua
@@ -177,7 +177,9 @@ local section = {
         val = {
             { type = "padding", val = 1 },
             { type = "text", val = "MRU", opts = { hl = "SpecialComment" } },
-            { type = "padding", val = 1 },
+            { type = "text", val = "Plain" },
+            { type = "text", val = "Centered", opts = { position = "center" } },
+            { type = "text", val = "Highlighted", opts = { hl = "Number" } },
             {
                 type = "group",
                 val = function()
@@ -191,7 +193,6 @@ local section = {
         val = {
             { type = "padding", val = 1 },
             { type = "text", val = mru_title, opts = { hl = "SpecialComment", shrink_margin = false } },
-            { type = "padding", val = 1 },
             {
                 type = "group",
                 val = function()

```
</details>


Before |  After
:-----:|:-------:
![](https://user-images.githubusercontent.com/6306455/178462328-96a5b116-25ef-41d5-af64-e75bfa21e377.png)  |  ![](https://user-images.githubusercontent.com/6306455/178462367-f257d4ba-ec31-4b96-ba95-0804cf2ffdb6.png)
