### PR TITLE
feat: command output as a header

### DIFF
--- a/doc/alpha.txt
+++ b/doc/alpha.txt
@@ -41,7 +41,7 @@ config:
     -- optional
     opts = {
         -- number: how much space to pad on the sides of the screen
-        margin = 0 
+        margin = 0
 
         -- theme-specific setup,
         -- ran once before the first draw
@@ -131,6 +131,29 @@ group:
     opts = {
         -- number of newlines inbetween each element
         spacing = 1
+    }
+ }
+<
+terminal:
+>
+ -- note: require'alpha.term' must be called
+ -- after require'alpha'
+ {
+    -- required
+    type = "terminal"
+    command = "string" -- the shell command to run
+    -- command size can be fixed, or calculated by mutating these
+    width = 0 -- number
+    height = 0 -- number
+
+    -- optional
+    opts = {
+        -- turns 'false' after the command is run
+        -- when redraw = true alpha will rerun the command
+        -- on the next redraw
+        redraw = true
+        -- see :h nvim_open_win {config} parameter
+        window_config = {}
     }
  }
 <

--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -534,10 +534,8 @@ function alpha.start(on_vimenter, conf)
     for i = 1, #conf.layout, 1 do
         if conf.layout[i].command then
             term.run_command(conf.layout[i].command, conf.layout[i].opts)
-            goto continue
         end
     end
-    ::continue::
 
     local function draw()
         for k in pairs(cursor_jumps) do

--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -484,6 +484,7 @@ end
 local current_config
 
 function alpha.start(on_vimenter, conf)
+    local term = require("alpha.term")
     local window = vim.api.nvim_get_current_win()
 
     alpha.move_cursor = function()
@@ -525,6 +526,9 @@ function alpha.start(on_vimenter, conf)
         window = window,
         win_width = 0,
     }
+
+    term.run_command:send()
+
     local function draw()
         for k in pairs(cursor_jumps) do
             cursor_jumps[k] = nil
@@ -560,6 +564,7 @@ function alpha.start(on_vimenter, conf)
     end
     alpha.redraw = draw
     alpha.close = function()
+        term.close_window()
         cursor_ix = 1
         cursor_jumps = {}
         cursor_jumps_press = {}

--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -326,11 +326,9 @@ local function layout(conf, state)
     local hl = {}
     local text = {}
     for _, el in pairs(conf.layout) do
-        if el.type ~= "terminal" then
-            local text_el, hl_el = layout_element[el.type](el, conf, state)
-            list_extend(text, text_el)
-            list_extend(hl, hl_el)
-        end
+        local text_el, hl_el = layout_element[el.type](el, conf, state)
+        list_extend(text, text_el)
+        list_extend(hl, hl_el)
     end
     vim.api.nvim_buf_set_lines(state.buffer, 0, -1, false, text)
     for _, hl_line in pairs(hl) do
@@ -370,9 +368,7 @@ end
 
 local function keymaps(conf, state)
     for _, el in pairs(conf.layout) do
-        if el.type ~= "terminal" then
-            keymaps_element[el.type](el, conf, state)
-        end
+        keymaps_element[el.type](el, conf, state)
     end
 end
 
@@ -488,7 +484,6 @@ end
 local current_config
 
 function alpha.start(on_vimenter, conf)
-    local term = require("alpha.term")
     local window = vim.api.nvim_get_current_win()
 
     alpha.move_cursor = function()
@@ -530,13 +525,6 @@ function alpha.start(on_vimenter, conf)
         window = window,
         win_width = 0,
     }
-
-    for i = 1, #conf.layout, 1 do
-        if conf.layout[i].command then
-            term.run_command(conf.layout[i].command, conf.layout[i].opts)
-        end
-    end
-
     local function draw()
         for k in pairs(cursor_jumps) do
             cursor_jumps[k] = nil
@@ -575,7 +563,6 @@ function alpha.start(on_vimenter, conf)
         cursor_ix = 1
         cursor_jumps = {}
         cursor_jumps_press = {}
-        term.close_window()
         alpha.redraw = noop
         vim.cmd([[au! alpha_temp]])
         vim.cmd([[doautocmd User AlphaClosed]])
@@ -586,10 +573,10 @@ function alpha.start(on_vimenter, conf)
 end
 
 function alpha.setup(config)
-    vim.validate({
-        config = { config, "table" },
-        layout = { config.layout, "table" },
-    })
+    vim.validate {
+      config = { config, "table" },
+      layout = { config.layout, "table" },
+    }
     current_config = config
 
     --[[

--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -575,9 +575,7 @@ function alpha.start(on_vimenter, conf)
         cursor_ix = 1
         cursor_jumps = {}
         cursor_jumps_press = {}
-        if term then
-            term.close_window()
-        end
+        term.close_window()
         alpha.redraw = noop
         vim.cmd([[au! alpha_temp]])
         vim.cmd([[doautocmd User AlphaClosed]])

--- a/lua/alpha/term.lua
+++ b/lua/alpha/term.lua
@@ -2,13 +2,13 @@ local alpha = require('alpha')
 
 local M = {}
 
-function M.open_window(opts)
-    local width = opts.width
-    local height = opts.height
+function M.open_window(el)
+    local width = el.width
+    local height = el.height
     local row = math.floor(height / 5)
     local col = math.floor((vim.o.columns - width) / 2)
 
-    opts = vim.tbl_extend('keep', opts, {
+    local opts = vim.tbl_extend((el.opts and el.opts.window_config) or {}, {
         relative = "editor",
         row = row,
         col = col,
@@ -23,14 +23,14 @@ function M.open_window(opts)
     return { bufnr, winid }
 end
 
-function M.run_command(cmd, opts)
+function M.run_command(cmd, el)
     if cmd == nil then
         return
     end
 
     vim.loop
         .new_async(vim.schedule_wrap(function()
-            local wininfo = M.open_window(opts)
+            local wininfo = M.open_window(el)
             vim.api.nvim_command("terminal " .. cmd)
             vim.api.nvim_command("wincmd j")
             vim.api.nvim_buf_set_option(wininfo[1], "buflisted", false)
@@ -53,9 +53,9 @@ vim.api.nvim_create_autocmd('User', {
 })
 
 function alpha.layout_element.terminal(el, _, _)
-    if el.redraw == nil or el.redraw then
-        el.redraw = false
-        M.run_command(el.command, el.opts)
+    if el.opts and (el.opts.redraw == nil or el.opts.redraw) then
+        el.opts.redraw = false
+        M.run_command(el.command, el)
     end
     return {}, {}
 end

--- a/lua/alpha/term.lua
+++ b/lua/alpha/term.lua
@@ -32,14 +32,14 @@ function M.run_command(cmd, opts)
             vim.api.nvim_command("terminal " .. cmd)
             vim.api.nvim_command("wincmd j")
             vim.api.nvim_buf_set_option(wininfo[1], "buflisted", false)
-            vim.api.nvim_win_set_var(0, "dashboard_preview_wininfo", wininfo)
-            vim.api.nvim_command('let b:term_title ="dashboard_preview" ')
+            vim.api.nvim_win_set_var(0, "alpha_section_terminal", wininfo)
+            vim.api.nvim_command('let b:term_title ="alpha_terminal" ')
         end))
         :send()
 end
 
 function M.close_window()
-    local ok, wininfo = pcall(vim.api.nvim_win_get_var, 0, "dashboard_preview_wininfo")
+    local ok, wininfo = pcall(vim.api.nvim_win_get_var, 0, "alpha_section_terminal")
     if ok and vim.api.nvim_buf_is_loaded(wininfo[1]) then
         vim.api.nvim_buf_delete(wininfo[1], { force = true })
     end

--- a/lua/alpha/term.lua
+++ b/lua/alpha/term.lua
@@ -1,0 +1,60 @@
+local M = {}
+
+function M.open_window(bufnr)
+    local width = 69
+    local height = 8
+    local row = math.floor(height / 5)
+    local col = math.floor((vim.o.columns - width) / 2)
+
+    local opts = {
+        relative = "editor",
+        row = row,
+        col = col,
+        width = width,
+        height = height,
+        style = "minimal",
+    }
+
+    if not bufnr then
+        bufnr = vim.api.nvim_create_buf(false, true)
+    end
+
+    local winid = vim.api.nvim_open_win(bufnr, true, opts)
+    vim.api.nvim_win_set_option(winid, "winhl", "Normal:DashboardTerminal")
+    vim.api.nvim_command("hi DashboardTerminal guibg=NONE gui=NONE")
+    return { bufnr, winid }
+end
+
+M.run_command = vim.loop.new_async(vim.schedule_wrap(function()
+    -- local file_path = ""
+    -- if type(db.preview_file_path) == "string" then
+    --     file_path = db.preview_file_path
+    -- elseif type(db.preview_file_path) == "function" then
+    --     file_path = db.preview_file_path()
+    -- else
+    --     vim.notify("wrong type of preview_file_path")
+    --     return
+    -- end
+
+    local wininfo = M.open_window()
+    local cmd = "cat | lolcat -F 0.3 ~/.config/nvim/static/neovim.cat"
+    vim.api.nvim_command("terminal " .. cmd)
+    vim.api.nvim_command("wincmd j")
+    vim.api.nvim_buf_set_option(wininfo[1], "buflisted", false)
+    vim.api.nvim_win_set_var(0, "dashboard_preview_wininfo", wininfo)
+    vim.api.nvim_command('let b:term_title ="dashboard_preview" ')
+end))
+
+function M.close_window()
+    local ok, wininfo = pcall(vim.api.nvim_win_get_var, 1, "dashboard_preview_wininfo")
+    if ok then
+        if vim.api.nvim_buf_is_loaded(wininfo[1]) then
+            vim.api.nvim_buf_delete(wininfo[1], { force = true })
+        end
+        if vim.api.nvim_win_is_valid(wininfo[2]) then
+            vim.api.nvim_win_close(wininfo[2], true)
+        end
+    end
+end
+
+return M

--- a/lua/alpha/term.lua
+++ b/lua/alpha/term.lua
@@ -8,7 +8,7 @@ function M.open_window(el)
     local row = math.floor(height / 5)
     local col = math.floor((vim.o.columns - width) / 2)
 
-    local opts = vim.tbl_extend((el.opts and el.opts.window_config) or {}, {
+    local opts = vim.tbl_extend('keep', (el.opts and el.opts.window_config) or {}, {
         relative = "editor",
         row = row,
         col = col,
@@ -24,6 +24,7 @@ function M.open_window(el)
 end
 
 function M.run_command(cmd, el)
+    print("cool")
     if cmd == nil then
         return
     end

--- a/lua/alpha/term.lua
+++ b/lua/alpha/term.lua
@@ -24,7 +24,6 @@ function M.open_window(el)
 end
 
 function M.run_command(cmd, el)
-    print("cool")
     if cmd == nil then
         return
     end

--- a/lua/alpha/term.lua
+++ b/lua/alpha/term.lua
@@ -1,3 +1,5 @@
+local alpha = require('alpha')
+
 local M = {}
 
 function M.open_window(opts)
@@ -6,14 +8,14 @@ function M.open_window(opts)
     local row = math.floor(height / 5)
     local col = math.floor((vim.o.columns - width) / 2)
 
-    local opts = {
+    opts = vim.tbl_extend('keep', opts, {
         relative = "editor",
         row = row,
         col = col,
         width = width,
         height = height,
         style = "minimal",
-    }
+    })
 
     local bufnr = vim.api.nvim_create_buf(false, true)
     local winid = vim.api.nvim_open_win(bufnr, true, opts)
@@ -43,6 +45,22 @@ function M.close_window()
     if ok and vim.api.nvim_buf_is_loaded(wininfo[1]) then
         vim.api.nvim_buf_delete(wininfo[1], { force = true })
     end
+end
+
+vim.api.nvim_create_autocmd('User', {
+    pattern = 'AlphaClosed',
+    callback = function () M.close_window() end,
+})
+
+function alpha.layout_element.terminal(el, _, _)
+    if el.redraw == nil or el.redraw then
+        el.redraw = false
+        M.run_command(el.command, el.opts)
+    end
+    return {}, {}
+end
+
+function alpha.keymaps_element.terminal(_, _, _)
 end
 
 return M

--- a/lua/alpha/term.lua
+++ b/lua/alpha/term.lua
@@ -1,8 +1,8 @@
 local M = {}
 
-function M.open_window(bufnr)
-    local width = 69
-    local height = 8
+function M.open_window(opts)
+    local width = opts.width
+    local height = opts.height
     local row = math.floor(height / 5)
     local col = math.floor((vim.o.columns - width) / 2)
 
@@ -15,45 +15,33 @@ function M.open_window(bufnr)
         style = "minimal",
     }
 
-    if not bufnr then
-        bufnr = vim.api.nvim_create_buf(false, true)
-    end
-
+    local bufnr = vim.api.nvim_create_buf(false, true)
     local winid = vim.api.nvim_open_win(bufnr, true, opts)
-    vim.api.nvim_win_set_option(winid, "winhl", "Normal:DashboardTerminal")
-    vim.api.nvim_command("hi DashboardTerminal guibg=NONE gui=NONE")
+    vim.api.nvim_win_set_option(winid, "winhl", "Normal:Normal")
     return { bufnr, winid }
 end
 
-M.run_command = vim.loop.new_async(vim.schedule_wrap(function()
-    -- local file_path = ""
-    -- if type(db.preview_file_path) == "string" then
-    --     file_path = db.preview_file_path
-    -- elseif type(db.preview_file_path) == "function" then
-    --     file_path = db.preview_file_path()
-    -- else
-    --     vim.notify("wrong type of preview_file_path")
-    --     return
-    -- end
+function M.run_command(cmd, opts)
+    if cmd == nil then
+        return
+    end
 
-    local wininfo = M.open_window()
-    local cmd = "cat | lolcat -F 0.3 ~/.config/nvim/static/neovim.cat"
-    vim.api.nvim_command("terminal " .. cmd)
-    vim.api.nvim_command("wincmd j")
-    vim.api.nvim_buf_set_option(wininfo[1], "buflisted", false)
-    vim.api.nvim_win_set_var(0, "dashboard_preview_wininfo", wininfo)
-    vim.api.nvim_command('let b:term_title ="dashboard_preview" ')
-end))
+    vim.loop
+        .new_async(vim.schedule_wrap(function()
+            local wininfo = M.open_window(opts)
+            vim.api.nvim_command("terminal " .. cmd)
+            vim.api.nvim_command("wincmd j")
+            vim.api.nvim_buf_set_option(wininfo[1], "buflisted", false)
+            vim.api.nvim_win_set_var(0, "dashboard_preview_wininfo", wininfo)
+            vim.api.nvim_command('let b:term_title ="dashboard_preview" ')
+        end))
+        :send()
+end
 
 function M.close_window()
-    local ok, wininfo = pcall(vim.api.nvim_win_get_var, 1, "dashboard_preview_wininfo")
-    if ok then
-        if vim.api.nvim_buf_is_loaded(wininfo[1]) then
-            vim.api.nvim_buf_delete(wininfo[1], { force = true })
-        end
-        if vim.api.nvim_win_is_valid(wininfo[2]) then
-            vim.api.nvim_win_close(wininfo[2], true)
-        end
+    local ok, wininfo = pcall(vim.api.nvim_win_get_var, 0, "dashboard_preview_wininfo")
+    if ok and vim.api.nvim_buf_is_loaded(wininfo[1]) then
+        vim.api.nvim_buf_delete(wininfo[1], { force = true })
     end
 end
 

--- a/lua/alpha/themes/dashboard.lua
+++ b/lua/alpha/themes/dashboard.lua
@@ -3,10 +3,12 @@ local if_nil = vim.F.if_nil
 local default_terminal = {
     type = "terminal",
     command = nil,
+    width = 69,
+    height = 8,
     opts = {
-        width = 69,
-        height = 8,
-    },
+        redraw = true,
+        window_config = {}
+    }
 }
 
 local default_header = {

--- a/lua/alpha/themes/dashboard.lua
+++ b/lua/alpha/themes/dashboard.lua
@@ -1,5 +1,14 @@
 local if_nil = vim.F.if_nil
 
+local default_terminal = {
+    type = "terminal",
+    command = nil,
+    opts = {
+        width = 69,
+        height = 8,
+    },
+}
+
 local default_header = {
     type = "text",
     val = {
@@ -79,6 +88,7 @@ local buttons = {
 }
 
 local section = {
+    terminal = default_terminal,
     header = default_header,
     buttons = buttons,
     footer = footer,


### PR DESCRIPTION
Firstly, I want to say this is heavily inspired by the awesome work on #63 by Ben. This pull request builds on that. Secondly, under no pressure to merge this into main at all. This is simply my itch that I wanted to scratch :wink:.

![Screen Shot 2022-07-13 at 19 47 10@2x](https://user-images.githubusercontent.com/9512444/178808425-5305d212-edf1-4e1c-962e-374430fe2acd.png)

## Goal
The primary aim of this pull request is to create a simple API (fitting in with the existing API) which displays the output from a command as my header in my existing dashboard.

## Context
I tried out [dashboard.nvim](https://github.com/glepnir/dashboard-nvim) again recently and the only positive it has over this plugin is its ability to display the output of a given command. It turned out it mattered to me quite a lot as I chase a glorious aesthetic of a Neovim dashboard.

## Summary
I analysted #63 quite significantly alongside the dashboard.nvim implementation and in truth, borrowed a significant chunk of the actual logic to display the command from the latter. Changes to `alpha.lua` are pretty minimal as most of the logic resides in a `term.lua` file.

But...in essence, the user passes a command to alpha-nvim which then runs it asynchronously before displaying it.

## My config

My config which I used in testing:

```lua
  local dashboard = require("alpha.themes.dashboard")

  -- Terminal header
  dashboard.section.terminal.command = "cat | lolcat -F 0.3 " .. os.getenv("HOME") .. "/.config/nvim/static/neovim.cat"
  dashboard.section.terminal.opts = {
    width = 69,
    height = 8,
  }

  local function button(sc, txt, keybind, keybind_opts)
    local b = dashboard.button(sc, txt, keybind, keybind_opts)
    b.opts.hl = "AlphaButtonText"
    b.opts.hl_shortcut = "AlphaButtonShortcut"
    return b
  end
  dashboard.section.buttons.val = {
    button("l", "   Load session", ':lua require("persisted").load()<CR>'),
    button("s", "   Find session", ":Telescope persisted<CR>"),
    button("n", "   New file", ":ene <BAR> startinsert <CR>"),
    button("b", "   Bookmarks", ":Telescope harpoon marks<CR>"),
    button("r", "   Recently used files", ":Telescope frecency<CR>"),
    button("f", "   Find file", ":Telescope find_files hidden=true path_display=smart<CR>"),
    button("u", "   Update plugins", ":lua om.PackerSync()<CR>"), -- Packer sync
    button("q", "   Quit Neovim", ":qa<CR>"),
  }
  dashboard.section.buttons.opts = {
    spacing = 0,
  }

  -- Footer
  local function footer()
    local total_plugins = #vim.tbl_keys(packer_plugins)
    local version = vim.version()
    local nvim_version_info = "  Neovim v" .. version.major .. "." .. version.minor .. "." .. version.patch

    return " " .. total_plugins .. " plugins" .. nvim_version_info
  end
  dashboard.section.footer.val = footer()
  dashboard.section.footer.opts.hl = "AlphaFooter"

  -- Layout
  dashboard.config.layout = {
    { type = "padding", val = 1 },
    dashboard.section.terminal,
    { type = "padding", val = 9 },
    dashboard.section.buttons,
    { type = "padding", val = 1 },
    dashboard.section.footer,
  }

  dashboard.opts.opts.noautocmd = true

  alpha.setup(dashboard.opts)
```

with [neovim.cat](https://github.com/olimorris/dotfiles/blob/main/.config/nvim/static/neovim.cat) being the file I serve up with `lolcat`.

## Next steps
There's not a whole lot else I would add to this so keen to seek your views on how we could make it slicker or more in keeping with your API. Finally, thanks for such a great and well written plugin.