### PR TITLE
Auto cd when selecting file from MRU

### DIFF
--- a/lua/alpha/themes/startify.lua
+++ b/lua/alpha/themes/startify.lua
@@ -75,7 +75,7 @@ local function icon(fn)
     return nwd.get_icon(fn, ext, { default = true })
 end
 
-local function file_button(fn, sc, short_fn)
+local function file_button(fn, sc, short_fn,autocd)
     short_fn = if_nil(short_fn, fn)
     local ico_txt
     local fb_hl = {}
@@ -94,7 +94,8 @@ local function file_button(fn, sc, short_fn)
     else
         ico_txt = ""
     end
-    local file_button_el = button(sc, ico_txt .. short_fn, "<cmd>e " .. fn .. " <CR>")
+    local cd_cmd = (autocd and " | cd %:p:h" or "")
+    local file_button_el = button(sc, ico_txt .. short_fn, "<cmd>e " .. fn .. cd_cmd .." <CR>")
     local fn_start = short_fn:match(".*[/\\]")
     if fn_start ~= nil then
         table.insert(fb_hl, { "Comment", #ico_txt - 2, #fn_start + #ico_txt - 2 })
@@ -109,6 +110,7 @@ local mru_opts = {
     ignore = function(path, ext)
         return (string.find(path, "COMMIT_EDITMSG")) or (vim.tbl_contains(default_mru_ignore, ext))
     end,
+    autocd = false
 }
 
 --- @param start number
@@ -142,7 +144,7 @@ local function mru(start, cwd, items_number, opts)
         else
             short_fn = fnamemodify(fn, ":~")
         end
-        local file_button_el = file_button(fn, tostring(i + start - 1), short_fn)
+        local file_button_el = file_button(fn, tostring(i + start - 1), short_fn,opts.autocd)
         tbl[i] = file_button_el
     end
     return {

--- a/lua/alpha/themes/theta.lua
+++ b/lua/alpha/themes/theta.lua
@@ -65,7 +65,7 @@ local mru_opts = {
     ignore = function(path, ext)
         return (string.find(path, "COMMIT_EDITMSG")) or (vim.tbl_contains(default_mru_ignore, ext))
     end,
-    autocd= false
+    autocd = false
 }
 
 --- @param start number

--- a/lua/alpha/themes/theta.lua
+++ b/lua/alpha/themes/theta.lua
@@ -29,7 +29,7 @@ local function icon(fn)
     return nwd.get_icon(fn, ext, { default = true })
 end
 
-local function file_button(fn, sc, short_fn)
+local function file_button(fn, sc, short_fn,autocd)
     short_fn = short_fn or fn
     local ico_txt
     local fb_hl = {}
@@ -49,7 +49,8 @@ local function file_button(fn, sc, short_fn)
     else
         ico_txt = ""
     end
-    local file_button_el = dashboard.button(sc, ico_txt .. short_fn, "<cmd>e " .. fn .. " <CR>")
+    local cd_cmd = (autocd and " | cd %:p:h" or "")
+    local file_button_el = dashboard.button(sc, ico_txt .. short_fn, "<cmd>e " .. fn .. cd_cmd .." <CR>")
     local fn_start = short_fn:match(".*[/\\]")
     if fn_start ~= nil then
         table.insert(fb_hl, { "Comment", #ico_txt - 2, #fn_start + #ico_txt })
@@ -64,6 +65,7 @@ local mru_opts = {
     ignore = function(path, ext)
         return (string.find(path, "COMMIT_EDITMSG")) or (vim.tbl_contains(default_mru_ignore, ext))
     end,
+    autocd= false
 }
 
 --- @param start number
@@ -109,7 +111,7 @@ local function mru(start, cwd, items_number, opts)
 
         local shortcut = tostring(i + start - 1)
 
-        local file_button_el = file_button(fn, shortcut, short_fn)
+        local file_button_el = file_button(fn, shortcut, short_fn,opts.autocd)
         tbl[i] = file_button_el
     end
     return {
@@ -119,7 +121,7 @@ local function mru(start, cwd, items_number, opts)
     }
 end
 
-local default_header = {
+local header = {
     type = "text",
     val = {
         [[                               __                ]],
@@ -177,7 +179,7 @@ local buttons = {
 local config = {
     layout = {
         { type = "padding", val = 2 },
-        default_header,
+        header,
         { type = "padding", val = 2 },
         section_mru,
         { type = "padding", val = 2 },
@@ -195,6 +197,10 @@ local config = {
 }
 
 return {
+    header = header,
+    buttons = buttons,
+    mru_opts = mru_opts,
     config = config,
     nvim_web_devicons = nvim_web_devicons,
+
 }


### PR DESCRIPTION
Fixing #52 

It is `off` by default, as to not cause any breaking changes.

If you want to use this just do : 

```lua
local theme = require("alpha.themes.theta") --or require("alpha.themes.startify")
theme.mru_opts.autocd = true
alpha.setup(theme.config)

```