### PR TITLE
fix: support lua function keybind

### DIFF
--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -356,15 +356,25 @@ local keymaps_element = {}
 keymaps_element.text = noop
 keymaps_element.padding = noop
 
+local function buf_set_keymap(buffer, map)
+    local opts = map[4] or {}
+    local rhs = map[3]
+    if type(rhs) == 'function' then
+        opts.callback = map[3]
+        rhs = ''
+    end
+    vim.api.nvim_buf_set_keymap(buffer, map[1], map[2], rhs, opts)
+end
+
 function keymaps_element.button(el, conf, state)
     if el.opts and el.opts.keymap then
         if type(el.opts.keymap[1]) == "table" then
             for _, map in el.opts.keymap do
-                vim.api.nvim_buf_set_keymap(state.buffer, map[1], map[2], map[3], map[4])
+                buf_set_keymap(state.buffer, map)
             end
         else
             local map = el.opts.keymap
-            vim.api.nvim_buf_set_keymap(state.buffer, map[1], map[2], map[3], map[4])
+            buf_set_keymap(state.buffer, map)
         end
     end
 end

--- a/lua/alpha/themes/dashboard.lua
+++ b/lua/alpha/themes/dashboard.lua
@@ -60,7 +60,7 @@ local function button(sc, txt, keybind, keybind_opts)
     end
 
     local function on_press()
-        local key = vim.api.nvim_replace_termcodes(keybind or sc_ .. "<Ignore>", true, false, true)
+        local key = vim.api.nvim_replace_termcodes(sc_ .. "<Ignore>", true, false, true)
         vim.api.nvim_feedkeys(key, "t", false)
     end
 

--- a/lua/alpha/themes/startify.lua
+++ b/lua/alpha/themes/startify.lua
@@ -43,7 +43,7 @@ local function button(sc, txt, keybind, keybind_opts)
     end
 
     local function on_press()
-        local key = vim.api.nvim_replace_termcodes(keybind .. "<Ignore>", true, false, true)
+        local key = vim.api.nvim_replace_termcodes(sc_ .. "<Ignore>", true, false, true)
         vim.api.nvim_feedkeys(key, "t", false)
     end
 


### PR DESCRIPTION
nvim_replace_termcodes(keybind) is redundant