### PR TITLE
fix: Alpha crashes on startup

### DIFF
--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -344,9 +344,9 @@ local function layout(conf, state)
         list_extend(text, text_el)
         list_extend(hl, hl_el)
     end
-    vim.api.nvim_buf_set_lines(state.buffer, 0, -1, false, text)
+    pcall(vim.api.nvim_buf_set_lines, state.buffer, 0, -1, false, text)
     for _, hl_line in pairs(hl) do
-        vim.api.nvim_buf_add_highlight(hl_line[1], hl_line[2], hl_line[3], hl_line[4], hl_line[5], hl_line[6])
+        pcall(vim.api.nvim_buf_add_highlight, hl_line[1], hl_line[2], hl_line[3], hl_line[4], hl_line[5], hl_line[6])
     end
 end
 
@@ -359,7 +359,7 @@ function keymaps_element.button(el, conf, state)
     if el.opts and el.opts.keymap then
         if type(el.opts.keymap[1]) == "table" then
             for _, map in el.opts.keymap do
-                vim.api.nvim_buf_set_keymap(state.buffer, map[1], map[2], map[3], map[4])
+                pcall(vim.api.nvim_buf_set_keymap, state.buffer, map[1], map[2], map[3], map[4])
             end
         else
             local map = el.opts.keymap
@@ -550,10 +550,10 @@ function alpha.draw(conf, state)
     -- when the screen is cleared and then redrawn
     -- so we save the index before that happens
     local ix = cursor_ix
-    vim.api.nvim_buf_set_option(state.buffer, "modifiable", true)
-    vim.api.nvim_buf_set_lines(state.buffer, 0, -1, false, {})
+    pcall(vim.api.nvim_buf_set_option, state.buffer, "modifiable", true)
+    pcall(vim.api.nvim_buf_set_lines, state.buffer, 0, -1, false, {})
     layout(conf, state)
-    vim.api.nvim_buf_set_option(state.buffer, "modifiable", false)
+    pcall(vim.api.nvim_buf_set_option, state.buffer, "modifiable", false)
     if vim.api.nvim_get_current_win() == state.window then
         if #cursor_jumps ~= 0 then
             vim.api.nvim_win_set_cursor(state.window, cursor_jumps[ix])
@@ -600,7 +600,7 @@ function alpha.start(on_vimenter, conf)
     else
         if vim.bo.ft ~= "alpha" then
             buffer = vim.api.nvim_create_buf(false, true)
-            vim.api.nvim_win_set_buf(window, buffer)
+            pcall(vim.api.nvim_win_set_buf, window, buffer)
         else
             buffer = vim.api.nvim_get_current_buf()
             vim.api.nvim_buf_delete(buffer, {})


### PR DESCRIPTION
Hi, I ran into an issue while trying to use your plugin. Some background - I started implementing/configuring it about a month ago, everything was fine at the time and I had to shelve it for a bit. Once I finally got back around to including it in my main config it started throwing these errors on startup (see attached screenshot & video). It's almost the same error as from #26, but this time it was throwing on multiple different calls. At first it seemed like some sort of conflict with [`git-conflict.nvim`](https://github.com/akinsho/git-conflict.nvim), but even after disabling that plugin Alpha still threw the same errors (I have since found a workaround to have both plugins work - just prevent `git-conflict` from loading on the dashboard screen). So after doing some digging, these changes fixed the issue for me. I really don't know if it's the best solution, I just based it off of your previous solution but I could imagine that this might just cover up a deeper problem. Please let me know if I've done something wrong or if there's a better way to solve this and I can make the according updates.

My current specs:

MacOS: 12.6 w/ 2.3 GHz, 8-core Intel i9, 32 Gig ram
Neovim: 0.8.0
And [my config](https://gitlab.com/KingEdwardI/neovim-config/-/tree/alpha-dashboard), if it helps.

(Also, I tried to run `stylua`, but a lot of other files changed so I undid that)

![Screen Shot 2022-11-18 at 5 15 16 PM](https://user-images.githubusercontent.com/20171781/202824203-2c91e419-e223-44bd-bec7-538601c22e46.png)


https://user-images.githubusercontent.com/20171781/202825241-536301c0-5b6a-4476-b9f2-3f51c567cc49.mp4
(The errors after everything loaded were from any keystroke)

And by the way, this is an awesome plugin - The configuration is really clean and I was able to do some pretty wild stuff with the dashboard image.