### PR TITLE
Export MRU function in theta theme

### DIFF
--- a/lua/alpha/themes/theta.lua
+++ b/lua/alpha/themes/theta.lua
@@ -199,6 +199,7 @@ local config = {
 return {
     header = header,
     buttons = buttons,
+    mru = mru,
     mru_opts = mru_opts,
     config = config,
     nvim_web_devicons = nvim_web_devicons,


### PR DESCRIPTION
Exporting the MRU function will allow users to customize their theta config with respect to MRU specifics, e.g. the shortcut starting number or the total number of items to be displayed.

Also see discussion https://github.com/goolord/alpha-nvim/discussions/159.