### PR TITLE
Update nvim-web-devicons references

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ With packer:
 ```lua
 use {
     'goolord/alpha-nvim',
-    requires = { 'kyazdani42/nvim-web-devicons' },
+    requires = { 'nvim-tree/nvim-web-devicons' },
     config = function ()
         require'alpha'.setup(require'alpha.themes.startify'.config)
     end
@@ -20,7 +20,7 @@ use {
 ```lua
 require "paq" {
     "goolord/alpha-nvim";
-    "kyazdani42/nvim-web-devicons";
+    "nvim-tree/nvim-web-devicons";
 }
 require'alpha'.setup(require'alpha.themes.startify'.config)
 ```
@@ -39,7 +39,7 @@ use {
 ```lua
 require "paq" {
     "goolord/alpha-nvim";
-    "kyazdani42/nvim-web-devicons";
+    "nvim-tree/nvim-web-devicons";
 }
 require'alpha'.setup(require'alpha.themes.dashboard'.config)
 ```

--- a/doc/alpha.txt
+++ b/doc/alpha.txt
@@ -228,7 +228,7 @@ Example with the startify theme:
 >
     use {
         "goolord/alpha-nvim",
-        requires = { 'kyazdani42/nvim-web-devicons' },
+        requires = { 'nvim-tree/nvim-web-devicons' },
         config = function ()
             local alpha = require'alpha'
             local startify = require'alpha.themes.startify'


### PR DESCRIPTION
The `nvim-web-devicons` repo was transferred from `kyazdani42/nvim-web-devicons` to [`nvim-tree/nvim-web-devicons`](https://github.com/nvim-tree/nvim-web-devicons).

This updates the docs to point to the updated repo.