### PR TITLE
fix: store alpha configuration to a user accessible variable

### DIFF
--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -653,10 +653,10 @@ function alpha.setup(config)
 
     config.opts = vim.tbl_extend("keep", if_nil(config.opts, {}), { autostart = true })
 
-    alpha.config = config
+    alpha.default_config = config
 
     vim.api.nvim_create_user_command("Alpha", function(_)
-        alpha.start(false, alpha.config)
+        alpha.start(false, config)
     end, {
         bang = true,
         desc = 'require"alpha".start(false)',
@@ -677,8 +677,8 @@ function alpha.setup(config)
         pattern = "*",
         nested = true,
         callback = function()
-            if alpha.config.opts.autostart then
-                alpha.start(true, alpha.config)
+            if config.opts.autostart then
+                alpha.start(true, config)
             end
         end,
     })

--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -653,8 +653,10 @@ function alpha.setup(config)
 
     config.opts = vim.tbl_extend("keep", if_nil(config.opts, {}), { autostart = true })
 
+    alpha.config = config
+
     vim.api.nvim_create_user_command("Alpha", function(_)
-        alpha.start(false, config)
+        alpha.start(false, alpha.config)
     end, {
         bang = true,
         desc = 'require"alpha".start(false)',
@@ -675,8 +677,8 @@ function alpha.setup(config)
         pattern = "*",
         nested = true,
         callback = function()
-            if config.opts.autostart then
-                alpha.start(true, config)
+            if alpha.config.opts.autostart then
+                alpha.start(true, alpha.config)
             end
         end,
     })


### PR DESCRIPTION
Proposed fix for the `alpha.start` command. This exposes the configuration from the `setup` call as `require("alpha").config`. This way you can call it with something like

```lua
require("alpha").start(true, require("alpha").config)
require("alpha").start(false, require("alpha").config)
```

Resolves #175 