### PR TITLE
feat: allow terminal cmd to be a function

### DIFF
--- a/lua/alpha/term.lua
+++ b/lua/alpha/term.lua
@@ -27,6 +27,10 @@ function M.run_command(cmd, el)
     if cmd == nil then
         return
     end
+    
+    if type(cmd) == 'function' then
+        cmd = cmd()
+    end
 
     vim.loop.new_async(vim.schedule_wrap(function()
         local wininfo = M.open_window(el)


### PR DESCRIPTION
Similarly to how `val` can be a function, this lets users define a function that returns the terminal command.

Why? Users might want to do expensive FS tasks in order to, say, get a random script and determine its dimensions.

Rather than running these expensive tasks in each start up in the `config` function, it's better to defer these until alpha actually draws the output