### PR TITLE
fix: pass alpha window to move_cursor() in CursorMoved callback

### DIFF
--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -485,21 +485,21 @@ local function enable_alpha(conf, state)
 
     vim.api.nvim_create_autocmd('BufUnload', {
         group = group_id,
-        pattern = '<buffer>',
+        buffer = state.buffer,
         callback = alpha.close,
     })
 
-    vim.api.nvim_create_autocmd({'WinClosed'}, {
+    vim.api.nvim_create_autocmd('WinClosed', {
         group = group_id,
-        pattern = '<buffer>',
+        buffer = state.buffer,
         callback = alpha.handle_window,
     })
 
     vim.api.nvim_create_autocmd('CursorMoved', {
         group = group_id,
-        pattern = '<buffer>',
+        buffer = state.buffer,
         -- FIXME: many windows can be associated with
-        callback = function() alpha.move_cursor(0) end,
+        callback = function() alpha.move_cursor(state.window) end,
     })
 
     if conf.opts then
@@ -595,6 +595,7 @@ function alpha.draw(conf, state)
 end
 
 function alpha.move_cursor(window)
+    window = window or 0
     if #cursor_jumps ~= 0 then
             local cursor = vim.api.nvim_win_get_cursor(window)
             local closest_ix, closest_pt = closest_cursor_jump(cursor, cursor_jumps, cursor_jumps[cursor_ix])


### PR DESCRIPTION
The `CursorMoved` autocmd should pass the explicit alpha window handle to `move_cursor()` (and on to the API calls). This doesn't directly address the `FIXME` comment directly above the change, but this does fix an actual [issue when using `alpha` and `fzf-lua`](https://github.com/ibhagwan/fzf-lua/issues/711).

Due to [this commit in neovim](https://github.com/neovim/neovim/commit/fedf002cb34d0d7a50c54f84a2f161984db2a4c2), `CursorMoved` autocmds are now fired when calling `vim.api.nvim_win_set_cursor()`. There's likely an upstream neovim bug in the mix here, but it seems that if we just tell the API to use the "current window" in that callback (even if its a buffer-local callback for the alpha buffer only), neovim gets confused and jacks up the offsets for determining where to open float windows. Its as if neovim is firing the CursorMoved callback for the alpha buffer, but the window has already been switched to the new float, so it tried to move the cursor in the wrong window.

Generally, probably better to be explicit about the specific windows and buffers in play for the autocommands since we have the handle numbers, anyway.

For reference, this is the PR and issue that I started this issue (and likely needs to be followed up with another fix):

https://github.com/neovim/neovim/pull/21072
https://github.com/neovim/neovim/issues/19063