### PR TITLE
feat: add an option to pass keymaps

### DIFF
--- a/doc/alpha.txt
+++ b/doc/alpha.txt
@@ -57,10 +57,11 @@ config:
 
         -- table of default keymaps
         keymap = {
-            -- string | string[]: key combinations used to press an item.
+            -- nil | string | string[]: key combinations used to press an
+            -- item.
             press = '<CR>',
-            -- string | string[]: key combination used to select an item to
-            press later.
+            -- nil | string | string[]: key combination used to select an item to
+            -- press later.
             press_queue = '<M-CR>'
         }
     }

--- a/doc/alpha.txt
+++ b/doc/alpha.txt
@@ -54,6 +54,15 @@ config:
         -- with other plguins.
         -- default: false (disabled)
         noautocmd = bool
+
+        -- table of default keymaps
+        keymap = {
+            -- string: key combination used to press an item (button).
+            press = '<CR>',
+            -- string: key combination used to select an item (button) to
+            press later.
+            press_queue = '<M-CR>'
+        }
     }
  }
 <

--- a/doc/alpha.txt
+++ b/doc/alpha.txt
@@ -57,9 +57,9 @@ config:
 
         -- table of default keymaps
         keymap = {
-            -- string: key combination used to press an item (button).
+            -- string | string[]: key combinations used to press an item.
             press = '<CR>',
-            -- string: key combination used to select an item (button) to
+            -- string | string[]: key combination used to select an item to
             press later.
             press_queue = '<M-CR>'
         }

--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -664,8 +664,12 @@ function alpha.start(on_vimenter, conf)
 
     alpha_state[buffer] = state
 
-    vim.keymap.set("n", "<CR>", function() alpha.press() end, { noremap = false, silent = true, buffer = state.buffer })
-    vim.keymap.set("n", "<M-CR>", function() alpha.queue_press(state) end, { noremap = false, silent = true, buffer = state.buffer })
+    if conf.opts.keymap.press then
+        vim.keymap.set("n", conf.opts.keymap.press, function() alpha.press() end, { noremap = false, silent = true, buffer = state.buffer })
+    end
+    if conf.opts.keymap.queue_press then
+        vim.keymap.set("n", conf.opts.keymap.queue_press, function() alpha.queue_press(state) end, { noremap = false, silent = true, buffer = state.buffer })
+    end
 
     enable_alpha(conf, state)
 
@@ -681,7 +685,17 @@ function alpha.setup(config)
         layout = { config.layout, "table" },
     })
 
-    config.opts = vim.tbl_extend("keep", if_nil(config.opts, {}), { autostart = true })
+    config.opts = vim.tbl_extend(
+        "keep",
+        if_nil(config.opts, {}),
+        {
+            autostart = true,
+            keymap = {
+                press = "<CR>",
+                queue_press = "<M-CR>",
+            }
+        }
+    )
 
     alpha.default_config = config
 

--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -79,6 +79,20 @@ local function spaces(n)
     return str_rep(" ", n)
 end
 
+---@param keymaps nil | string | string[]
+---@return string[]
+local function convert_keymaps(keymaps)
+    if not keymaps then
+        return {}
+    end
+
+    if type(keymaps) ~= "table" then
+        keymaps = { keymaps }
+    end
+
+    return keymaps
+end
+
 function alpha.align_center(tbl, state)
     -- longest line used to calculate the center.
     -- which doesn't quite give a 'justfieid' look, but w.e
@@ -664,11 +678,11 @@ function alpha.start(on_vimenter, conf)
 
     alpha_state[buffer] = state
 
-    if conf.opts.keymap.press then
-        vim.keymap.set("n", conf.opts.keymap.press, function() alpha.press() end, { noremap = false, silent = true, buffer = state.buffer })
+    for _, k in ipairs(convert_keymaps(conf.opts.keymap.press)) do
+        vim.keymap.set("n", k, function() alpha.press() end, { noremap = false, silent = true, buffer = state.buffer })
     end
-    if conf.opts.keymap.queue_press then
-        vim.keymap.set("n", conf.opts.keymap.queue_press, function() alpha.queue_press(state) end, { noremap = false, silent = true, buffer = state.buffer })
+    for _, k in ipairs(convert_keymaps(conf.opts.keymap.queue_press)) do
+        vim.keymap.set("n", k, function() alpha.queue_press(state) end, { noremap = false, silent = true, buffer = state.buffer })
     end
 
     enable_alpha(conf, state)


### PR DESCRIPTION
This plugin binds `<CR>` and `<M-CR>` by default, which can conflict with custom keymaps. This MR adds an option to change these default mappings by passing new argument in `setup()`.

Previous binds are now default values for these options. Values can be either a string or a list of strings (one or many mappings), or `nil` (remove mapping).

Here is an example configuration:
```lua
require('alpha').setup {
    ...,
    opts = {
        keymap = {
            -- Press action is now triggered for both "ENTER" and "l"
            press = { '<CR>', 'l' },
            -- Queue press is removed
            queue_press = nil
        }
    }
}
```