### PR TITLE
fixed enter key throwing error

### DIFF
--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -37,7 +37,9 @@ end
 function alpha.press()
     -- only press under the cursor if there's no queue
     if vim.tbl_count(cursor_jumps_press_queue) == 0 then
+      if cursor_jumps_press[cursor_ix] then
         cursor_jumps_press[cursor_ix]()
+      end
     end
     for queued_cursor_ix, _ in pairs(cursor_jumps_press_queue) do
         cursor_jumps_press[queued_cursor_ix]()


### PR DESCRIPTION
When you have no buttons and press the enter key, an error gets thrown. This simple check fixes it.

Example Config:
```lua
return {
  'goolord/alpha-nvim',
  config = function()
    local alpha = require 'alpha'
    local dashboard = require 'alpha.themes.dashboard'
    local api = vim.api

    dashboard.section.buttons.val = {}

    dashboard.section.header.opts.hl = 'Include'
    dashboard.section.buttons.opts.hl = 'Macro'
    dashboard.section.footer.opts.hl = 'Type'
    dashboard.opts.opts.noautocmd = true

    alpha.setup(dashboard.opts)
  end,
}
```

Error Thrown:
E5108: Error executing lua: ...rs/tobin/.local/share/nvim/lazy/alpha-nvim/lua/alpha.lua:40: attempt to call a nil value                             
stack traceback:                                                                                                                                    
        ...rs/tobin/.local/share/nvim/lazy/alpha-nvim/lua/alpha.lua:40: in function 'press'                                                         
        ...rs/tobin/.local/share/nvim/lazy/alpha-nvim/lua/alpha.lua:705: in function <...rs/tobin/.local/share/nvim/lazy/alpha-nvim/lua/alpha.lua:70
5>
