### PR TITLE
fix: Button keymap assignment

### DIFF
--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -404,14 +404,8 @@ keymaps_element.padding = noop
 ---@diagnostic disable-next-line: unused-local
 function keymaps_element.button(el, conf, state)
     if el.opts and el.opts.keymap then
-        if type(el.opts.keymap[1]) == "table" then
-            for _, map in el.opts.keymap do
-                vim.api.nvim_buf_set_keymap(state.buffer, map[1], map[2], map[3], map[4])
-            end
-        else
-            local map = el.opts.keymap
-            vim.api.nvim_buf_set_keymap(state.buffer, map[1], map[2], map[3], map[4])
-        end
+        el.opts.keymap[4] = vim.tbl_extend("force", el.opts.keymap[4] or {}, { buffer = state.buffer })
+        vim.keymap.set(unpack(el.opts.keymap))
     end
 end
 


### PR DESCRIPTION
This directly addresses two things:

1. Fixed handling of multi-mode mappings
2. Allow passing a lua function as the mapping RHS

`opts.keymap` is now passed to `vim.keymap.set` instead of `nvim_buf_set_keymap` because it handles all of the work needed to support multi-mode mappings and functions as RHS, eliminating most of the work needed to be done here.

## Example use case

I have a button that loads the last saved session via persistence.nvim and prints a message. With this patch, I can define a button like this:

```lua
local function callback()
	print('Loading session')
	require('persistence').load { last = true }
end

local button = {
	type = 'button',
	val = 'Restore Last Session',
	on_press = callback,
	opts = {
		-- blah blah
		keymap = { 'n', shortcut, callback, {} }
	}
}
```