### PR TITLE
fix: only delete valid buffers on alpha close

### DIFF
--- a/lua/alpha/term.lua
+++ b/lua/alpha/term.lua
@@ -40,7 +40,9 @@ function M.run_command(cmd, el, state, line)
         vim.api.nvim_create_autocmd("User", {
             pattern = "AlphaClosed",
             callback = function()
-                vim.api.nvim_buf_delete(wininfo[1], { force = true })
+                if vim.api.nvim_buf_is_valid(wininfo[1]) then
+                    vim.api.nvim_buf_delete(wininfo[1], { force = true })
+                end
             end,
         })
         vim.api.nvim_command("terminal " .. cmd)


### PR DESCRIPTION
Hope you're all having a good day.

Encountered a problem when restoring sessions in AstroVim.

To see the problem:

1. Install [AstroVim](https://github.com/AstroNvim/AstroNvim/tree/main)
2. Add the following to `~/.config/nvim/lua/user/plugins/user.lua`:
```lua
{
    "goolord/alpha-nvim",
    opts = function()
      local dashboard = require "alpha.themes.dashboard"
      require('alpha.term')

      dashboard.section.terminal.command = "cowsay I have herd you have a bug. Moo-tivating fix in progress."
      dashboard.section.terminal.width = 42
      dashboard.section.terminal.height = 16
      dashboard.section.terminal.opts.redraw = true
      dashboard.section.terminal.opts.window_config.zindex = 1

      dashboard.section.header.val = {
        "NeoVim",
      }
      dashboard.section.terminal.opts.hl = "DashboardHeader"
      dashboard.section.footer.opts.hl = "DashboardFooter"

      dashboard.config.layout = {
        { type = "padding", val = vim.fn.max { 2, vim.fn.floor(vim.fn.winheight(0) * 0.2) } },
        dashboard.section.terminal,
        { type = "padding", val = 2 },
        dashboard.section.header,
        { type = "padding", val = 3 },
        dashboard.section.buttons,
        { type = "padding", val = 3 },
        dashboard.section.footer,
      }
      dashboard.config.opts.noautocmd = true
      return dashboard
    end,
  },
```
3. Use the `<Space>Sl` remap to load a previous session and observe the error.