### PR TITLE
Fix: Close alpha after SessionLoadPost.

### DIFF
--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -508,6 +508,11 @@ local function enable_alpha(conf, state)
         callback = alpha.close,
     })
 
+    vim.api.nvim_create_autocmd('SessionLoadPost', {
+        group = group_id,
+        callback = alpha.close,
+    })
+
     vim.api.nvim_create_autocmd({'WinClosed'}, {
         group = group_id,
         buffer = state.buffer,

--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -502,9 +502,14 @@ local function enable_alpha(conf, state)
 
     local group_id = vim.api.nvim_create_augroup('alpha_temp', { clear = true })
 
-    vim.api.nvim_create_autocmd({'BufUnload', 'SessionLoadPost'}, {
+    vim.api.nvim_create_autocmd('BufUnload', {
         group = group_id,
         buffer = state.buffer,
+        callback = alpha.close,
+    })
+
+    vim.api.nvim_create_autocmd('SessionLoadPost', {
+        group = group_id,
         callback = alpha.close,
     })
 

--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -502,14 +502,9 @@ local function enable_alpha(conf, state)
 
     local group_id = vim.api.nvim_create_augroup('alpha_temp', { clear = true })
 
-    vim.api.nvim_create_autocmd('BufUnload', {
+    vim.api.nvim_create_autocmd({'BufUnload', 'SessionLoadPost'}, {
         group = group_id,
         buffer = state.buffer,
-        callback = alpha.close,
-    })
-
-    vim.api.nvim_create_autocmd('SessionLoadPost', {
-        group = group_id,
         callback = alpha.close,
     })
 


### PR DESCRIPTION
Problem:
 - Alpha use a autocmd base on `BufUnload` to close alpha's instance.
 - `BufUnload` will not be triggered by source a session file.
 - Alpha will still try to redraw after buffer closed by loading a session, causing invalid buffer error since these autocmds were not cleared properly.

Solution:
 - Add autocmd base on `SessionLoadPost` to close alpha after sourcing a session file.