### PR TITLE
Small update to theta.lua for small niche video game operating system.

### DIFF
--- a/lua/alpha/themes/theta.lua
+++ b/lua/alpha/themes/theta.lua
@@ -169,7 +169,7 @@ local buttons = {
         dashboard.button("e", "  New file", "<cmd>ene<CR>"),
         dashboard.button("SPC f f", "󰈞  Find file"),
         dashboard.button("SPC f g", "󰊄  Live grep"),
-        dashboard.button("c", "  Configuration", "<cmd>cd ~/.config/nvim/ <CR>"),
+        dashboard.button("c", "  Configuration", "<cmd>cd " .. (package.config:sub(1,1) == "\\" and "$LOCALAPPDATA/nvim/" or "~/.config/nvim/") .. " <CR>"),
         dashboard.button("u", "  Update plugins", "<cmd>Lazy sync<CR>"),
         dashboard.button("q", "󰅚  Quit", "<cmd>qa<CR>"),
     },


### PR DESCRIPTION
Change configuration option of Theta Layout so that Windows computers, as well as Linux computers, can use the 'C' shortcut to cd into config folder.
Accomplished using a test from [StackOverflow](https://stackoverflow.com/questions/295052/how-can-i-determine-the-os-of-the-system-from-within-a-lua-script), testing the the slash character, combined with and/or semantics to create an inline ["ternary"](http://lua-users.org/wiki/TernaryOperator) string concatenation.

Solves the cd on my windows 10 pc, ending up at "C:\Users\USER\AppData\Local\nvim", which is the default nvim configuration folder on Windows.

No styling done since it's a simple line change and my stylua goes haywire with non-related changes if I save it :^)
I'll defer to whatever styling you prefer here.