### PR TITLE
fix: redraw terminal elements on subsequent Alpha redraws

### DIFF
--- a/lua/alpha/term.lua
+++ b/lua/alpha/term.lua
@@ -40,6 +40,7 @@ function M.run_command(cmd, el, state, line)
         vim.api.nvim_create_autocmd("User", {
             pattern = "AlphaClosed",
             callback = function()
+                el.opts.redraw = true
                 if vim.api.nvim_buf_is_valid(wininfo[1]) then
                     vim.api.nvim_buf_delete(wininfo[1], { force = true })
                 end


### PR DESCRIPTION
The `alpha.term` extension deletes the terminal buffer on `AlphaClosed`, which causes an `Invalid window id: ...` error when the plugin tries to redraw things. This PR makes it so that it sets the `redraw` option back to `true` when the Alpha buffer is closed. Doing it this way still avoids the infinite redraw problem that this flag was preventing.

This should solve the issue reported here: https://github.com/goolord/alpha-nvim/issues/275