### PR TITLE
Fix Theta theme config path

### DIFF
--- a/lua/alpha/themes/theta.lua
+++ b/lua/alpha/themes/theta.lua
@@ -169,7 +169,7 @@ local buttons = {
         dashboard.button("e", "  New file", "<cmd>ene<CR>"),
         dashboard.button("SPC f f", "󰈞  Find file"),
         dashboard.button("SPC f g", "󰊄  Live grep"),
-        dashboard.button("c", "  Configuration", "<cmd>cd ~/.config/nvim/ <CR>"),
+        dashboard.button("c", "  Configuration", "<cmd>cd stdpath('config')<CR>"),
         dashboard.button("u", "  Update plugins", "<cmd>Lazy sync<CR>"),
         dashboard.button("q", "󰅚  Quit", "<cmd>qa<CR>"),
     },


### PR DESCRIPTION
Hi,
The config path is hardcoded in the theta theme yielding an error on Windows when pressing `c`.
I'm aware of PR #280 but i think using the builtin vim function `stdpath('config')` is simpler and easier to understand for new users to customize the theta theme.