### PR TITLE
fix: redraw only if the buffer is valid

### DIFF
--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -651,6 +651,9 @@ function alpha.move_cursor(window)
 end
 
 function alpha.redraw(conf, state)
+    if not vim.api.nvim_buf_is_valid(state.buffer) then
+        return
+    end
     if (conf == nil) and (state == nil) then
         local buffer = vim.api.nvim_get_current_buf()
         local alpha_prime = vim.tbl_get(alpha_state, buffer) or head(alpha_state)


### PR DESCRIPTION
Hi, and thank you for a great plugin.

This PR addresses an issue where Alpha attempts to redraw when the buffer is invalid, causing the `WinResized` autocmd to trigger in a loop.

       Error  12:10:54 AM msg_show.lua_error Error detected while processing WinResized Autocommands for "*":

I encountered this issue using [this script](https://gitlab.com/Biggybi/neovim-conf/-/blob/master/lua/core/autoscratch.lua).

It seems to occur if an autocmd on `VimEnter` opens buffers that we edit/resize.

I believe this check is reasonable, but I understand if you feel it should not be Alpha's responsibility.

Related: #282.