### PR TITLE
feat: support mini.icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ With [lazy.nvim](https://github.com/folke/lazy.nvim):
 ```lua
 {
     'goolord/alpha-nvim',
-    dependencies = { 'nvim-tree/nvim-web-devicons' },
+    dependencies = { 'echasnovski/mini.icons' },
     config = function ()
         require'alpha'.setup(require'alpha.themes.startify'.config)
     end
@@ -23,7 +23,7 @@ With packer:
 ```lua
 use {
     'goolord/alpha-nvim',
-    requires = { 'nvim-tree/nvim-web-devicons' },
+    requires = { 'echasnovski/mini.icons' },
     config = function ()
         require'alpha'.setup(require'alpha.themes.startify'.config)
     end
@@ -33,7 +33,7 @@ use {
 ```lua
 require "paq" {
     "goolord/alpha-nvim";
-    "nvim-tree/nvim-web-devicons";
+    "echasnovski/mini.icons";
 }
 require'alpha'.setup(require'alpha.themes.startify'.config)
 ```
@@ -66,7 +66,7 @@ use {
 ```lua
 require "paq" {
     "goolord/alpha-nvim";
-    "nvim-tree/nvim-web-devicons";
+    "echasnovski/mini.icons";
 }
 require'alpha'.setup(require'alpha.themes.dashboard'.config)
 ```
@@ -81,7 +81,7 @@ With [lazy.nvim](https://github.com/folke/lazy.nvim):
 {
     'goolord/alpha-nvim',
     dependencies = {
-        'nvim-tree/nvim-web-devicons',
+        'echasnovski/mini.icons',
         'nvim-lua/plenary.nvim'
     },
     config = function ()
@@ -94,7 +94,7 @@ With packer:
 use {
     'goolord/alpha-nvim',
     requires = {
-        'nvim-tree/nvim-web-devicons',
+        'echasnovski/mini.icons',
         'nvim-lua/plenary.nvim'
     },
     config = function ()
@@ -106,19 +106,45 @@ use {
 ```lua
 require "paq" {
     "goolord/alpha-nvim";
-    "nvim-tree/nvim-web-devicons";
+    "echasnovski/mini.icons";
     'nvim-lua/plenary.nvim';
 }
 require'alpha'.setup(require'alpha.themes.dashboard'.config)
 ```
 </details>
 
-if you want sessions, see 
+if you want sessions, see
 - https://github.com/Shatur/neovim-session-manager
 - :h :mks
 
 this theme makes some assumptions about your default keybindings
 to customize the buttons, see :h alpha-example
+
+#### File Icons
+
+theta/startify theme support file icons, default is enabled and `mini` icon provider is used.
+
+- [nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons)
+- [mini-icons](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-icons.md)
+
+if you prefer `nvim-web-devicons` icon provider, use the following example with lazy.nvim:
+
+```
+  {
+    "goolord/alpha-nvim",
+    -- dependencies = { 'echasnovski/mini.icons' },
+    dependencies = { 'nvim-tree/nvim-web-devicons' },
+    config = function()
+      local startify = require("alpha.themes.startify")
+      -- available: devicons, mini, default is mini
+      -- if provider not loaded and enabled is true, it will try to use another provider
+      startify.file_icons.provider = "devicons"
+      require("alpha").setup(
+        startify.config
+      )
+    end,
+  },
+```
 
 ## Elevator pitch
 alpha is really a general purpose neovim ui library with some conveniences for writing a greeter ui.

--- a/doc/alpha.txt
+++ b/doc/alpha.txt
@@ -236,13 +236,16 @@ theta/startify:
     autocd = false
  }
 
- nvim_web_devicons = {
+ file_icons = {
      -- enable / disable icons in the MRU menu entries
      -- defaults to
      enabled = true,
      -- enable / disable highlighting for the icons in the MRU menu entries
      -- defaults to
      highlight = true,
+     -- available: devicons, mini, to use nvim-web-devicons or mini.icons
+     -- if provider not loaded and enabled is true, it will try to use another provider
+     provider = "mini",
  }
 <
 
@@ -294,7 +297,7 @@ Example with the startify theme:
 >
     use {
         "goolord/alpha-nvim",
-        requires = { 'nvim-tree/nvim-web-devicons' },
+        requires = { 'echasnovski/mini.icons' },
         config = function ()
             local alpha = require'alpha'
             local startify = require'alpha.themes.startify'
@@ -313,10 +316,10 @@ Example with the startify theme:
             startify.section.mru.val = { { type = "padding", val = 0 } }
             -- disable MRU cwd
             startify.section.mru_cwd.val = { { type = "padding", val = 0 } }
-            -- disable nvim_web_devicons
-            startify.nvim_web_devicons.enabled = false
-            -- startify.nvim_web_devicons.highlight = false
-            -- startify.nvim_web_devicons.highlight = 'Keyword'
+            -- disable file_icons
+            startify.file_icons.enabled = false
+            -- startify.file_icons.highlight = false
+            -- startify.file_icons.highlight = 'Keyword'
             --
             startify.section.bottom_buttons.val = {
                 startify.button( "q", "󰅚  Quit NVIM" , ":qa<CR>"),

--- a/lua/alpha/themes/theta.lua
+++ b/lua/alpha/themes/theta.lua
@@ -1,5 +1,7 @@
 -- originally authored by @AdamWhittingham
 
+local utils = require("alpha.utils")
+
 local path_ok, plenary_path = pcall(require, "plenary.path")
 if not path_ok then
     return
@@ -9,48 +11,52 @@ local dashboard = require("alpha.themes.dashboard")
 local cdir = vim.fn.getcwd()
 local if_nil = vim.F.if_nil
 
-local nvim_web_devicons = {
+local file_icons = {
     enabled = true,
     highlight = true,
+    -- available: devicons, mini, to use nvim-web-devicons or mini.icons
+    -- if provider not loaded and enabled is true, it will try to use another provider
+    provider = "mini",
 }
 
-local function get_extension(fn)
-    local match = fn:match("^.+(%..+)$")
-    local ext = ""
-    if match ~= nil then
-        ext = match:sub(2)
-    end
-    return ext
-end
-
 local function icon(fn)
-    local nwd = require("nvim-web-devicons")
-    local ext = get_extension(fn)
-    return nwd.get_icon(fn, ext, { default = true })
+    if file_icons.provider ~= "devicons" and file_icons.provider ~= "mini" then
+        vim.notify("Alpha: Invalid file icons provider: " .. file_icons.provider .. ", disable file icons", vim.log.levels.WARN)
+        file_icons.enabled = false
+        return "", ""
+    end
+
+    local ico, hl = utils.get_file_icon(file_icons.provider, fn)
+    if ico == "" then
+        file_icons.enabled = false
+        vim.notify("Alpha: Mini icons or devicons get icon failed, disable file icons", vim.log.levels.WARN)
+    end
+    return ico, hl
 end
 
-local function file_button(fn, sc, short_fn,autocd)
+local function file_button(fn, sc, short_fn, autocd)
     short_fn = short_fn or fn
     local ico_txt
     local fb_hl = {}
 
-    if nvim_web_devicons.enabled then
+    if file_icons.enabled then
         local ico, hl = icon(fn)
-        local hl_option_type = type(nvim_web_devicons.highlight)
+        local hl_option_type = type(file_icons.highlight)
         if hl_option_type == "boolean" then
-            if hl and nvim_web_devicons.highlight then
+            if hl and file_icons.highlight then
                 table.insert(fb_hl, { hl, 0, #ico })
             end
         end
         if hl_option_type == "string" then
-            table.insert(fb_hl, { nvim_web_devicons.highlight, 0, #ico })
+            table.insert(fb_hl, { file_icons.highlight, 0, #ico })
         end
         ico_txt = ico .. "  "
     else
         ico_txt = ""
     end
     local cd_cmd = (autocd and " | cd %:p:h" or "")
-    local file_button_el = dashboard.button(sc, ico_txt .. short_fn, "<cmd>e " .. vim.fn.fnameescape(fn) .. cd_cmd .." <CR>")
+    local file_button_el =
+        dashboard.button(sc, ico_txt .. short_fn, "<cmd>e " .. vim.fn.fnameescape(fn) .. cd_cmd .. " <CR>")
     local fn_start = short_fn:match(".*[/\\]")
     if fn_start ~= nil then
         table.insert(fb_hl, { "Comment", #ico_txt - 2, #fn_start + #ico_txt })
@@ -65,7 +71,7 @@ local mru_opts = {
     ignore = function(path, ext)
         return (string.find(path, "COMMIT_EDITMSG")) or (vim.tbl_contains(default_mru_ignore, ext))
     end,
-    autocd = false
+    autocd = false,
 }
 
 --- @param start number
@@ -86,7 +92,7 @@ local function mru(start, cwd, items_number, opts)
         else
             cwd_cond = vim.startswith(v, cwd)
         end
-        local ignore = (opts.ignore and opts.ignore(v, get_extension(v))) or false
+        local ignore = (opts.ignore and opts.ignore(v, utils.get_extension(v))) or false
         if (vim.fn.filereadable(v) == 1) and cwd_cond and not ignore then
             oldfiles[#oldfiles + 1] = v
         end
@@ -111,7 +117,7 @@ local function mru(start, cwd, items_number, opts)
 
         local shortcut = tostring(i + start - 1)
 
-        local file_button_el = file_button(fn, shortcut, short_fn,opts.autocd)
+        local file_button_el = file_button(fn, shortcut, short_fn, opts.autocd)
         tbl[i] = file_button_el
     end
     return {
@@ -208,5 +214,7 @@ return {
     -- theme specific config
     mru_opts = mru_opts,
     leader = dashboard.leader,
-    nvim_web_devicons = nvim_web_devicons,
+    file_icons = file_icons,
+    -- deprecated
+    nvim_web_devicons = file_icons,
 }

--- a/lua/alpha/utils.lua
+++ b/lua/alpha/utils.lua
@@ -1,0 +1,56 @@
+local M = {}
+
+--- @param fn string file name or path
+--- @return string
+function M.get_extension(fn)
+    local basename = vim.fs.basename(fn)
+    local match = basename:match("^.+(%..+)$")
+    local ext = ""
+    if match ~= nil then
+        ext = match:sub(2)
+    end
+    return ext
+end
+
+local has_devicons, devicons = pcall(require, "nvim-web-devicons")
+local has_mini_icons, mini_icons = pcall(require, "mini.icons")
+local function devicons_get_icon(fn, ext)
+    return devicons.get_icon(fn, ext, { default = true })
+end
+local function mini_get_icon(fn, ext)
+    if ext ~= "" then
+        local icon, hl, _ = mini_icons.get("extension", ext)
+        return icon, hl
+    else
+        local icon, hl, _ = mini_icons.get("file", fn)
+        return icon, hl
+    end
+end
+
+--- @param provider string devicons or mini
+--- @param fn string file name or path
+--- @return string, string
+function M.get_file_icon(provider, fn)
+    if not has_devicons and not has_mini_icons then
+        return "", ""
+    end
+
+    local ext = M.get_extension(fn)
+    if provider == "devicons" then
+        -- if devicons is not installed, fallback to mini icons
+        if not has_devicons then
+            return mini_get_icon(fn, ext)
+        end
+        return devicons_get_icon(fn, ext)
+    end
+    if provider == "mini" then
+        -- if mini icons is not installed, fallback to devicons
+        if not has_mini_icons then
+            return devicons_get_icon(fn, ext)
+        end
+        return mini_get_icon(fn, ext)
+    end
+    return "", ""
+end
+
+return M


### PR DESCRIPTION
https://github.com/echasnovski/mini.icons

- mini.icons has both "glyph" and "ascii" style.
- faster then nvim-web-devicons.
<img width="544" alt="Snipaste_2024-07-30_20-59-10" src="https://github.com/user-attachments/assets/a4ccfa0c-bb56-4ddf-91da-c4bc4e95fb09">



### changes
- default use mini.icons, config provider in require("alpha.themes.startify").file_icons.provider
- backward compatibility, require("alpha.themes.startify").nvim_web_devicons mark `deprecated`
- fix get_extension when path has '.', ex: a/b.c/makefile
- use vim.notify warning instead of stacktrace error