### PR TITLE
Delay closing of alpha to avoid quitting vim when only one tab is open

### DIFF
--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -514,8 +514,13 @@ local function enable_alpha(conf, state)
             group = group_id,
             buffer = state.buffer,
             callback = function(ev)
-                vim.api.nvim_buf_delete(ev.buf, {})
-                alpha.close(ev)
+                local function check_and_delete_alpha_buf()
+                    alpha.close(ev)
+                    vim.api.nvim_buf_delete(ev.buf, {})
+                end
+
+                local timer = vim.loop.new_timer()
+                timer:start(1000, 0, vim.schedule_wrap(check_and_delete_alpha_buf))
             end,
         })
     end


### PR DESCRIPTION
One way to address the issue I was seeing in this issue: https://github.com/goolord/alpha-nvim/issues/213

It doesn't seem super elegant, but it didn't seem as if hooking into another autocommand event would help at all