### PR TITLE
fix: rendering shortcuts in long lines

### DIFF
--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -284,7 +284,7 @@ function layout_element.button(el, conf, state)
             end
         end
         if opts.align_shortcut == "right" then
-            val = { concat({ el.val, spaces(padding.center), opts.shortcut }) }
+            val = { concat({ el.val, spaces(math.max(padding.center,1)), opts.shortcut }) }
         else
             val = { concat({ opts.shortcut, el.val, spaces(padding.right) }) }
         end
@@ -324,7 +324,7 @@ function layout_element.button(el, conf, state)
             hl = el.opts.hl_shortcut
         end
         if el.opts.align_shortcut == "right" then
-            hl = alpha.highlight(state, state.line, hl, #el.val + math.max(0,padding.center), el)
+            hl = alpha.highlight(state, state.line, hl, #el.val + math.max(padding.center,padding.left), el)
         else
             hl = alpha.highlight(state, state.line, hl, padding.left, el)
         end


### PR DESCRIPTION
This patch
- adds an extra space before the shortcut label if `padding.center` is less than `1`,
- calculates correct position of shortcut when highlighting it by taking into account both `padding.center` and `padding.left`.

#### Current rendering of long lines in Theta theme:

![alpha-nvim-garbled](https://github.com/user-attachments/assets/600ca145-a694-4416-a481-a82cae679264)

#### Fixed rendering:

![alpha-nvim-fixed](https://github.com/user-attachments/assets/7efec6b4-f82b-402a-963a-601ce094af4c)
