### PR TITLE
return section_mru in theta theme

### DIFF
--- a/lua/alpha/themes/theta.lua
+++ b/lua/alpha/themes/theta.lua
@@ -20,7 +20,10 @@ local file_icons = {
 
 local function icon(fn)
     if file_icons.provider ~= "devicons" and file_icons.provider ~= "mini" then
-        vim.notify("Alpha: Invalid file icons provider: " .. file_icons.provider .. ", disable file icons", vim.log.levels.WARN)
+        vim.notify(
+            "Alpha: Invalid file icons provider: " .. file_icons.provider .. ", disable file icons",
+            vim.log.levels.WARN
+        )
         file_icons.enabled = false
         return "", ""
     end
@@ -193,12 +196,12 @@ local config = {
     opts = {
         margin = 5,
         setup = function()
-            vim.api.nvim_create_autocmd('DirChanged', {
-                pattern = '*',
+            vim.api.nvim_create_autocmd("DirChanged", {
+                pattern = "*",
                 group = "alpha_temp",
-                callback = function ()
-                    require('alpha').redraw()
-                    vim.cmd('AlphaRemap')
+                callback = function()
+                    require("alpha").redraw()
+                    vim.cmd("AlphaRemap")
                 end,
             })
         end,
@@ -209,6 +212,7 @@ return {
     header = header,
     buttons = buttons,
     mru = mru,
+    section_mru = section_mru,
     config = config,
     -- theme specific config
     mru_opts = mru_opts,


### PR DESCRIPTION
Return section_mru in theta theme so that people can configure layout like this:
```lua
config = function()
	local theta = require("alpha.themes.theta")
	theta.header.val = require("alpha.fortune")
	theta.config.layout = {
		{ type = "padding", val = 2 },
		theta.header,
		{ type = "padding", val = 2 },
		theta.section_mru,
		{ type = "padding", val = 2 },
	}
	require("alpha").setup(theta.config)
end,
```
i.e., remove `buttons`. Note that we can't access `theta.section_mru` if not return it.