### PR TITLE
fix: prevent vim.validate deprecation warnings on neovim 0.11+

### DIFF
--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -727,10 +727,15 @@ function alpha.start(on_vimenter, conf)
 end
 
 function alpha.setup(config)
-    vim.validate({
-        config = { config, "table" },
-        layout = { config.layout, "table" },
-    })
+    if vim.fn.has('nvim-0.11') == 1 then
+        vim.validate("config", config, "table")
+        vim.validate("config.layout", config.layout, "table")
+    else
+        vim.validate({
+            config = { config, "table" },
+            layout = { config.layout, "table" },
+        })
+    end
 
     config.opts = vim.tbl_extend(
         "keep",


### PR DESCRIPTION
Fixes a deprecation warning from Neovim 0.11+ about `vim.validate`.

Similar to #321 except that the new syntax is made conditional on the version of Neovim being used, for backwards compatibility.