### PR TITLE
feat: Add support for custom `set_lines` function

### DIFF
--- a/doc/alpha.txt
+++ b/doc/alpha.txt
@@ -55,6 +55,10 @@ config:
         -- default: false (disabled)
         noautocmd = bool
 
+	-- a custom function to set the lines of the buffer,
+	-- defaults to `vim.api.nvim_buf_set_lines`
+	set_lines = function
+
         -- table of default keymaps
         keymap = {
             -- nil | string | string[]: key combinations used to press an

--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -17,7 +17,7 @@ local cursor_jumps_press_queue = {}
 -- map of buffer -> state
 local alpha_state = {}
 local function head(t)
-    local next,_,_ = pairs(t)
+    local next, _, _ = pairs(t)
     return t[next(t)]
 end
 
@@ -63,14 +63,13 @@ function alpha.queue_press(state)
     if cursor_jumps_press_queue[cursor_ix] then
         cursor_jumps_press_queue[cursor_ix] = nil
     else
-
         local cursor = vim.api.nvim_win_get_cursor(active_window(state))
         local row = cursor[1]
         local col = cursor[2]
 
-        cursor_jumps_press_queue[cursor_ix] = {row,col}
+        cursor_jumps_press_queue[cursor_ix] = { row, col }
 
-        draw_press(row,col,state)
+        draw_press(row, col, state)
         local height = state.line
         vim.api.nvim_win_set_cursor(0, { math.min(row + 1, height), col })
     end
@@ -182,7 +181,7 @@ function alpha.highlight(state, end_ln, hl, left, el)
         end
         if hl[1] and hl[1][1] and type(hl[1][1]) == "table" then
             for ix, hl_line in ipairs(hl) do
-                single_line(hl_line, ix-1)
+                single_line(hl_line, ix - 1)
             end
         else
             single_line(hl, 0)
@@ -214,11 +213,11 @@ function layout_element.text(el, conf, state)
     end
     local hl = {}
     local padding = { left = 0 }
-    local margin = vim.tbl_get(conf, 'opts', 'margin')
-    local position = vim.tbl_get(el, 'opts', 'position')
+    local margin = vim.tbl_get(conf, "opts", "margin")
+    local position = vim.tbl_get(el, "opts", "position")
     if margin and (position ~= "center") then
         local left
-        val, left = alpha.pad_margin(val, state, margin, if_nil(vim.tbl_get(el, 'opts', 'shrink_margin'), true))
+        val, left = alpha.pad_margin(val, state, margin, if_nil(vim.tbl_get(el, "opts", "shrink_margin"), true))
         padding.left = padding.left + left
     end
     if position == "center" then
@@ -226,7 +225,7 @@ function layout_element.text(el, conf, state)
         val, left = alpha.align_center(val, state)
         padding.left = padding.left + left
     end
-    local el_hl = vim.tbl_get(el, 'opts', 'hl')
+    local el_hl = vim.tbl_get(el, "opts", "hl")
     if type(el.val) == "string" then
         if el_hl then
             hl = alpha.highlight(state, state.line, el_hl, padding.left, el)
@@ -240,7 +239,6 @@ function layout_element.text(el, conf, state)
         state.line = end_ln
     end
     return val, hl
-
 end
 
 ---@diagnostic disable-next-line: unused-local
@@ -269,9 +267,9 @@ function layout_element.button(el, conf, state)
         center = 0,
         right = 0,
     }
-    local opts = vim.tbl_get(el, 'opts') or {}
-    local shortcut = vim.tbl_get(opts, 'shortcut')
-    local width = vim.tbl_get(opts, 'width')
+    local opts = vim.tbl_get(el, "opts") or {}
+    local shortcut = vim.tbl_get(opts, "shortcut")
+    local width = vim.tbl_get(opts, "width")
     if shortcut then
         -- this min lets the padding resize when the window gets smaller
         if width then
@@ -293,10 +291,10 @@ function layout_element.button(el, conf, state)
     end
 
     -- margin
-    if vim.tbl_get(conf, 'opts', 'margin') and (vim.tbl_get(opts, 'position') ~= "center") then
+    if vim.tbl_get(conf, "opts", "margin") and (vim.tbl_get(opts, "position") ~= "center") then
         local left
-        val, left = alpha.pad_margin(val, state, conf.opts.margin, if_nil(vim.tbl_get(opts, 'shrink_margin'), true))
-        if vim.tbl_get(opts, 'align_shortcut') == "right" then
+        val, left = alpha.pad_margin(val, state, conf.opts.margin, if_nil(vim.tbl_get(opts, "shrink_margin"), true))
+        if vim.tbl_get(opts, "align_shortcut") == "right" then
             padding.center = padding.center + left
         else
             padding.left = padding.left + left
@@ -304,7 +302,7 @@ function layout_element.button(el, conf, state)
     end
 
     -- center
-    if vim.tbl_get(el, 'opts', 'position') == "center" then
+    if vim.tbl_get(el, "opts", "position") == "center" then
         local left
         val, left = alpha.align_center(val, state)
         if el.opts.align_shortcut == "right" then
@@ -324,7 +322,7 @@ function layout_element.button(el, conf, state)
             hl = el.opts.hl_shortcut
         end
         if el.opts.align_shortcut == "right" then
-            hl = alpha.highlight(state, state.line, hl, #el.val + math.max(0,padding.center), el)
+            hl = alpha.highlight(state, state.line, hl, #el.val + math.max(0, padding.center), el)
         else
             hl = alpha.highlight(state, state.line, hl, padding.left, el)
         end
@@ -349,12 +347,12 @@ function layout_element.group(el, conf, state)
     if type(el.val) == "table" then
         local text_tbl = {}
         local hl_tbl = {}
-        local priority = if_nil(vim.tbl_get(el, 'opts', 'priority'), 1)
-        local inherit = vim.tbl_get(el, 'opts', 'inherit')
+        local priority = if_nil(vim.tbl_get(el, "opts", "priority"), 1)
+        local inherit = vim.tbl_get(el, "opts", "inherit")
         for _, v in pairs(el.val) do
             if inherit then
                 if v.opts then
-                    local vpriority = if_nil(vim.tbl_get(v, 'opts', 'priority'), 0)
+                    local vpriority = if_nil(vim.tbl_get(v, "opts", "priority"), 0)
                     if priority > vpriority then
                         v.opts = vim.tbl_extend("force", v.opts, inherit)
                     end
@@ -390,9 +388,19 @@ local function layout(conf, state)
         list_extend(text, text_el)
         list_extend(hl, hl_el)
     end
-    vim.api.nvim_buf_set_lines(state.buffer, 0, -1, false, text)
+
+    local set_lines = vim.tbl_get(conf, "opts", "set_lines") or vim.api.nvim_buf_set_lines
+    set_lines(state.buffer, 0, -1, false, text)
+
     for _, hl_line in pairs(hl) do
-        vim.api.nvim_buf_add_highlight(hl_line[1], hl_line[2], hl_line[3], hl_line[4], math.max(hl_line[5], 0), hl_line[6])
+        vim.api.nvim_buf_add_highlight(
+            hl_line[1],
+            hl_line[2],
+            hl_line[3],
+            hl_line[4],
+            math.max(hl_line[5], 0),
+            hl_line[6]
+        )
     end
 end
 
@@ -456,7 +464,8 @@ local function closest_cursor_jump(cursor, cursors, prev_cursor)
             end
         end
     end
-    if not min -- top or bottom
+    if
+        not min -- top or bottom
     then
         if direction then
             return 1, cursors[1]
@@ -613,7 +622,9 @@ end
 
 function alpha.draw(conf, state)
     -- TODO: figure out why this can happen
-    if #state.windows == 0 then return end
+    if #state.windows == 0 then
+        return
+    end
 
     cursor_jumps = {}
     cursor_jumps_press = {}
@@ -625,7 +636,10 @@ function alpha.draw(conf, state)
     local ix = cursor_ix
     vim.api.nvim_buf_set_option(state.buffer, "modifiable", true)
     vim.api.nvim_buf_clear_namespace(state.buffer, -1, 0, -1)
-    vim.api.nvim_buf_set_lines(state.buffer, 0, -1, false, {})
+
+    local set_lines = vim.tbl_get(conf, "opts", "set_lines") or vim.api.nvim_buf_set_lines
+    set_lines(state.buffer, 0, -1, false, {})
+
     layout(conf, state)
     vim.api.nvim_buf_set_option(state.buffer, "modifiable", false)
     local active_win = active_window(state)
@@ -646,7 +660,7 @@ function alpha.move_cursor(window)
         local closest_ix, closest_pt = closest_cursor_jump(cursor, cursor_jumps, cursor_jumps[cursor_ix])
         local closest_pt_vc = vim.fn.virtcol2col(window, closest_pt[1], closest_pt[2])
         cursor_ix = closest_ix
-        pcall(vim.api.nvim_win_set_cursor, window, {closest_pt[1], closest_pt_vc})
+        pcall(vim.api.nvim_win_set_cursor, window, { closest_pt[1], closest_pt_vc })
     end
 end
 
@@ -654,7 +668,9 @@ function alpha.redraw(conf, state)
     if (conf == nil) and (state == nil) then
         local buffer = vim.api.nvim_get_current_buf()
         local alpha_prime = vim.tbl_get(alpha_state, buffer) or head(alpha_state)
-        if alpha_prime == nil then return end
+        if alpha_prime == nil then
+            return
+        end
         conf = alpha.default_config
         state = alpha_prime
     end
@@ -686,7 +702,7 @@ function alpha.start(on_vimenter, conf)
             vim.api.nvim_win_set_buf(window, buffer)
         else
             ---@diagnostic disable-next-line: param-type-mismatch
-            if not pcall(vim.cmd, 'e #') then
+            if not pcall(vim.cmd, "e #") then
                 buffer = vim.api.nvim_get_current_buf()
                 vim.api.nvim_buf_delete(buffer, {})
             end
@@ -712,10 +728,14 @@ function alpha.start(on_vimenter, conf)
     alpha_state[buffer] = state
 
     for _, k in ipairs(normalize_keymaps(conf.opts.keymap.press)) do
-        vim.keymap.set("n", k, function() alpha.press() end, { noremap = false, silent = true, buffer = state.buffer })
+        vim.keymap.set("n", k, function()
+            alpha.press()
+        end, { noremap = false, silent = true, buffer = state.buffer })
     end
     for _, k in ipairs(normalize_keymaps(conf.opts.keymap.queue_press)) do
-        vim.keymap.set("n", k, function() alpha.queue_press(state) end, { noremap = false, silent = true, buffer = state.buffer })
+        vim.keymap.set("n", k, function()
+            alpha.queue_press(state)
+        end, { noremap = false, silent = true, buffer = state.buffer })
     end
 
     enable_alpha(conf, state)
@@ -727,7 +747,7 @@ function alpha.start(on_vimenter, conf)
 end
 
 function alpha.setup(config)
-    if vim.fn.has('nvim-0.11') == 1 then
+    if vim.fn.has("nvim-0.11") == 1 then
         vim.validate("config", config, "table")
         vim.validate("config.layout", config.layout, "table")
     else
@@ -737,17 +757,16 @@ function alpha.setup(config)
         })
     end
 
-    config.opts = vim.tbl_extend(
-        "keep",
-        if_nil(config.opts, {}),
-        {
-            autostart = true,
-            keymap = vim.tbl_extend("keep", if_nil(vim.tbl_get(config, "opts", "keymap"), {}), {
-                press = "<CR>",
-                queue_press = "<M-CR>",
-            })
-        }
-    )
+    config.opts = vim.tbl_extend("keep", if_nil(config.opts, {}), {
+        autostart = true,
+        set_lines = vim.api.nvim_buf_set_lines,
+        keymap = vim.tbl_extend("keep", if_nil(vim.tbl_get(config, "opts", "keymap"), {}), {
+            press = "<CR>",
+            queue_press = "<M-CR>",
+        }),
+    })
+
+    alpha.default_config = config
 
     alpha.default_config = config
 
@@ -771,13 +790,15 @@ function alpha.setup(config)
     vim.api.nvim_create_user_command("AlphaRemap", function(_)
         local buffer = vim.api.nvim_get_current_buf()
         local alpha_prime = vim.tbl_get(alpha_state, buffer) or head(alpha_state)
-        if alpha_prime == nil then return end
+        if alpha_prime == nil then
+            return
+        end
         local conf = alpha.default_config
         local state = alpha_prime
         keymaps(conf, state)
     end, {
         bang = true,
-        desc = 'manually set keymaps',
+        desc = "manually set keymaps",
         nargs = 0,
         bar = true,
     })
@@ -803,9 +824,7 @@ function alpha.handle_window(x)
     if alpha_instance then
         local wins = vim.tbl_filter(function(win)
             return (vim.api.nvim_win_get_buf(win) == x.buf) and (win ~= current_win)
-        end
-            , vim.api.nvim_list_wins()
-        )
+        end, vim.api.nvim_list_wins())
         alpha_instance.windows = wins
     end
 end

--- a/lua/alpha.lua
+++ b/lua/alpha.lua
@@ -768,8 +768,6 @@ function alpha.setup(config)
 
     alpha.default_config = config
 
-    alpha.default_config = config
-
     vim.api.nvim_create_user_command("Alpha", function(_)
         alpha.start(false, config)
     end, {


### PR DESCRIPTION
### Goal  
This PR lets users provide their own `set_lines` function through `config.opts`.  

### Why?  
This makes it possible to work with plugins like  
[baleia.nvim](https://github.com/m00qek/baleia.nvim), and allows things like  
ANSI-colored ASCII art or logs to be shown on startup.  

### Notes  
- No breaking changes  
- Core functionality remains the same if no custom `set_lines` is provided  

