### PR TITLE
Fix: Fixing Theta-Menu Button for selecting .config

### DIFF
--- a/lua/alpha/themes/theta.lua
+++ b/lua/alpha/themes/theta.lua
@@ -18,6 +18,29 @@ local file_icons = {
     provider = "mini",
 }
 
+-- Function to open the relevant config file
+-- Takes into accoutn vim or lua setup 
+local function open_config_local() 
+  local config_path = vim.fn.stdpath("config")
+  vim.api.nvim_set_current_dir(config_path)
+
+  -- Select init.* file base on setup
+  local init_lua = config_path .. "/init.lua"
+  local init_vim = config_path .. "/init.vim"
+
+  if vim.fn.filereadable(init_lua) == 1 then
+    vim.cmd("edit " .. init_lua)
+  elseif vim.fn.filereadable(init_vim) == 1 then
+    vim.cmd("edit " .. init_vim)
+  else
+    print("No init.* file found in " .. config_path)
+    print("Fallback to config path")
+    vim.cmd("cd " .. config_path)
+  end
+end 
+-- Makes function globally available to be used in cmd-button
+_G.open_config = open_config_local
+
 local function icon(fn)
     if file_icons.provider ~= "devicons" and file_icons.provider ~= "mini" then
         vim.notify("Alpha: Invalid file icons provider: " .. file_icons.provider .. ", disable file icons", vim.log.levels.WARN)
@@ -174,7 +197,7 @@ local buttons = {
         dashboard.button("e", "  New file", "<cmd>ene<CR>"),
         dashboard.button("SPC f f", "󰈞  Find file"),
         dashboard.button("SPC f g", "󰊄  Live grep"),
-        dashboard.button("c", "  Configuration", "<cmd>cd stdpath('config')<CR>"),
+        dashboard.button("c", "  Configuration", "<cmd>lua open_config()<CR>"),
         dashboard.button("u", "  Update plugins", "<cmd>Lazy sync<CR>"),
         dashboard.button("q", "󰅚  Quit", "<cmd>qa<CR>"),
     },


### PR DESCRIPTION
Info on Neovim Version/Linux:
6.18.2-arch2-1
NVIM v0.11.5
Build type: RelWithDebInfo
LuaJIT 2.1.1765228720

Error:
Received an error that the stdpath('config') is not valid.
<img width="795" height="78" alt="error_nvim_alpha_theta_menu" src="https://github.com/user-attachments/assets/a6f1fd30-5d90-429c-a9ee-043031c15f19" />


Fix:
Adding new function _open_config_local_ which searches for the current neovim config directory returned from stdpath('config') and opens the active init.lua or init.vim file.
Fallback to just the config directory in case on init.lua or init.vim file is available.