### PR TITLE
fix: config path syntax error in theta theme

### DIFF
--- a/lua/alpha/themes/theta.lua
+++ b/lua/alpha/themes/theta.lua
@@ -174,7 +174,7 @@ local buttons = {
         dashboard.button("e", "  New file", "<cmd>ene<CR>"),
         dashboard.button("SPC f f", "󰈞  Find file"),
         dashboard.button("SPC f g", "󰊄  Live grep"),
-        dashboard.button("c", "  Configuration", "<cmd>cd stdpath('config')<CR>"),
+        dashboard.button("c", "  Configuration", "<cmd>exec 'cd ' . stdpath('config')<CR>"),
         dashboard.button("u", "  Update plugins", "<cmd>Lazy sync<CR>"),
         dashboard.button("q", "󰅚  Quit", "<cmd>qa<CR>"),
     },


### PR DESCRIPTION
When entering command `:cd stdpath('config')`, Vim tries to `cd` into a directory _literally_ named `stdpath('config')`. This PR fixes it by first expanding the `stdpath()` function using `exec`.

<img width="1333" height="236" alt="error due to Vim trying to cd into a directory literally named stdpath-config" src="https://github.com/user-attachments/assets/1bf2db88-3417-4177-a23b-73486c4b3433" />