### PR TITLE
Fix command execution for configuration button

### DIFF
--- a/lua/alpha/themes/theta.lua
+++ b/lua/alpha/themes/theta.lua
@@ -174,7 +174,7 @@ local buttons = {
         dashboard.button("e", "  New file", "<cmd>ene<CR>"),
         dashboard.button("SPC f f", "󰈞  Find file"),
         dashboard.button("SPC f g", "󰊄  Live grep"),
-        dashboard.button("c", "  Configuration", "<cmd>cd stdpath('config')<CR>"),
+        dashboard.button("c", "  Configuration", "<cmd>exe 'cd' stdpath('config')<CR>"),
         dashboard.button("u", "  Update plugins", "<cmd>Lazy sync<CR>"),
         dashboard.button("q", "󰅚  Quit", "<cmd>qa<CR>"),
     },


### PR DESCRIPTION
:cd stdpath("config") gives an error, while :exe "cd" stdpath("config") does not